### PR TITLE
feat(binding-mcp): make McpToolSearchIndex async

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndex.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndex.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchDocument;
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
@@ -35,6 +36,7 @@ final class McpKeywordToolSearchIndex implements McpToolSearchIndex
     private static final double K1 = 1.2;
     private static final double B = 0.75;
 
+    private final Consumer<Runnable> dispatch;
     private final List<String> fields;
     private final Map<String, Double> weights;
 
@@ -44,16 +46,19 @@ final class McpKeywordToolSearchIndex implements McpToolSearchIndex
     private double averageDocumentLength;
 
     McpKeywordToolSearchIndex(
+        Consumer<Runnable> dispatch,
         List<String> fields,
         Map<String, Double> weights)
     {
+        this.dispatch = dispatch;
         this.fields = fields != null ? fields : List.of();
         this.weights = weights != null ? weights : Map.of();
     }
 
     @Override
     public void index(
-        Collection<McpToolSearchDocument> documents)
+        Collection<McpToolSearchDocument> documents,
+        CompletionCallback<Void> completed)
     {
         termFrequenciesByDocument.clear();
         documentLengths.clear();
@@ -96,11 +101,14 @@ final class McpKeywordToolSearchIndex implements McpToolSearchIndex
 
         int documentCount = documentLengths.size();
         averageDocumentLength = documentCount == 0 ? 0.0 : totalLength / documentCount;
+
+        dispatch.accept(() -> completed.completed(null));
     }
 
     @Override
-    public List<McpToolSearchMatch> query(
-        String text)
+    public void query(
+        String text,
+        CompletionCallback<List<McpToolSearchMatch>> completed)
     {
         List<String> queryTerms = McpTextTokenizer.tokenize(text);
         List<McpToolSearchMatch> matches = new ArrayList<>();
@@ -139,6 +147,6 @@ final class McpKeywordToolSearchIndex implements McpToolSearchIndex
             matches.sort((a, b) -> Double.compare(b.score, a.score));
         }
 
-        return matches;
+        dispatch.accept(() -> completed.completed(matches));
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndexFactorySpi.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndexFactorySpi.java
@@ -21,6 +21,7 @@ import io.aklivity.zilla.config.binding.mcp.McpKeywordToolSearchIndexConfig;
 import io.aklivity.zilla.config.binding.mcp.McpToolSearchIndexConfig;
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndexFactorySpi;
+import io.aklivity.zilla.runtime.engine.EngineContext;
 
 public final class McpKeywordToolSearchIndexFactorySpi implements McpToolSearchIndexFactorySpi
 {
@@ -32,10 +33,11 @@ public final class McpKeywordToolSearchIndexFactorySpi implements McpToolSearchI
 
     @Override
     public McpToolSearchIndex create(
+        EngineContext context,
         McpToolSearchIndexConfig config,
         List<String> fields,
         Map<String, Double> weights)
     {
-        return new McpKeywordToolSearchIndex(fields, weights);
+        return new McpKeywordToolSearchIndex(context::dispatch, fields, weights);
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchComposite.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchComposite.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.search;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchDocument;
@@ -26,6 +27,12 @@ import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
  * Composes any number of configured {@link McpToolSearchIndex} backends behind a single
  * {@link McpToolSearchIndex}, fusing their rankings with Reciprocal Rank Fusion. A single
  * backend is queried directly, with no fusion overhead.
+ * <p>
+ * Fans an {@link #index(Collection, CompletionCallback)} or {@link #query(String,
+ * CompletionCallback)} call out to every configured backend and joins once all have
+ * completed; the first failure reported by any backend is forwarded as the composite's own
+ * failure, discarding any results still outstanding from the others.
+ * </p>
  */
 public final class McpToolSearchComposite implements McpToolSearchIndex
 {
@@ -39,28 +46,92 @@ public final class McpToolSearchComposite implements McpToolSearchIndex
 
     @Override
     public void index(
-        Collection<McpToolSearchDocument> documents)
+        Collection<McpToolSearchDocument> documents,
+        CompletionCallback<Void> completed)
     {
-        indexes.forEach(index -> index.index(documents));
-    }
-
-    @Override
-    public List<McpToolSearchMatch> query(
-        String text)
-    {
-        List<McpToolSearchMatch> result;
-
         if (indexes.size() == 1)
         {
-            result = indexes.get(0).query(text);
+            indexes.get(0).index(documents, completed);
         }
         else
         {
-            List<List<McpToolSearchMatch>> rankings = new ArrayList<>(indexes.size());
-            indexes.forEach(index -> rankings.add(index.query(text)));
-            result = McpToolSearchRankFusion.fuse(rankings);
-        }
+            final int[] remaining = { indexes.size() };
+            final boolean[] settled = { false };
 
-        return result;
+            for (McpToolSearchIndex index : indexes)
+            {
+                index.index(documents, new CompletionCallback<>()
+                {
+                    @Override
+                    public void completed(
+                        Void result)
+                    {
+                        if (--remaining[0] == 0 && !settled[0])
+                        {
+                            settled[0] = true;
+                            completed.completed(null);
+                        }
+                    }
+
+                    @Override
+                    public void failed(
+                        Throwable ex)
+                    {
+                        if (!settled[0])
+                        {
+                            settled[0] = true;
+                            completed.failed(ex);
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    @Override
+    public void query(
+        String text,
+        CompletionCallback<List<McpToolSearchMatch>> completed)
+    {
+        if (indexes.size() == 1)
+        {
+            indexes.get(0).query(text, completed);
+        }
+        else
+        {
+            final List<List<McpToolSearchMatch>> rankings = new ArrayList<>(Collections.nCopies(indexes.size(), null));
+            final int[] remaining = { indexes.size() };
+            final boolean[] settled = { false };
+
+            for (int i = 0; i < indexes.size(); i++)
+            {
+                final int slot = i;
+                indexes.get(i).query(text, new CompletionCallback<>()
+                {
+                    @Override
+                    public void completed(
+                        List<McpToolSearchMatch> matches)
+                    {
+                        rankings.set(slot, matches);
+                        if (--remaining[0] == 0 && !settled[0])
+                        {
+                            settled[0] = true;
+                            completed.completed(McpToolSearchRankFusion.fuse(rankings));
+                        }
+                    }
+
+                    @Override
+                    public void failed(
+                        Throwable ex)
+                    {
+                        if (!settled[0])
+                        {
+                            settled[0] = true;
+                            completed.failed(ex);
+                        }
+                    }
+                });
+            }
+        }
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchIndexFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchIndexFactory.java
@@ -27,6 +27,7 @@ import io.aklivity.zilla.config.binding.mcp.McpCacheToolsSearchConfig;
 import io.aklivity.zilla.config.binding.mcp.McpToolSearchIndexConfig;
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndexFactorySpi;
+import io.aklivity.zilla.runtime.engine.EngineContext;
 
 /**
  * Builds the runtime {@link McpToolSearchIndex} for a configured
@@ -48,6 +49,7 @@ public final class McpToolSearchIndexFactory
     }
 
     public McpToolSearchIndex create(
+        EngineContext context,
         McpCacheToolsSearchConfig search)
     {
         McpToolSearchIndex result = null;
@@ -60,7 +62,7 @@ public final class McpToolSearchIndexFactory
                 McpToolSearchIndexFactorySpi factory = factoriesByType.get(config.type);
                 if (factory != null)
                 {
-                    indexes.add(factory.create(config, search.fields, search.weights));
+                    indexes.add(factory.create(context, config, search.fields, search.weights));
                 }
             }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
@@ -51,6 +51,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpResetExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ResetFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.ExpandableDirectByteBufferEx;
@@ -1376,12 +1377,35 @@ abstract class McpProxyItemFactory implements BindingHandler
             else
             {
                 final int limit = scanner.maxResults > 0 ? Math.min(scanner.maxResults, limitDefault) : limitDefault;
-                final byte[] bytes = buildResponse(query, limit);
-                cachedBuf = new UnsafeBufferEx(bytes);
-                cachedLen = bytes.length;
-                ready = true;
-                emitIfReady(traceId);
+                cache.searchIndex().query(query, new McpToolSearchIndex.CompletionCallback<>()
+                {
+                    @Override
+                    public void completed(
+                        List<McpToolSearchMatch> matches)
+                    {
+                        onQueryMatched(traceId, matches, limit);
+                    }
+
+                    @Override
+                    public void failed(
+                        Throwable ex)
+                    {
+                        onQueryMatched(traceId, List.of(), limit);
+                    }
+                });
             }
+        }
+
+        private void onQueryMatched(
+            long traceId,
+            List<McpToolSearchMatch> matches,
+            int limit)
+        {
+            final byte[] bytes = buildResponse(matches, limit);
+            cachedBuf = new UnsafeBufferEx(bytes);
+            cachedLen = bytes.length;
+            ready = true;
+            emitIfReady(traceId);
         }
 
         // MCP's CallToolResult.content only accepts text/image/audio/resource_link/resource blocks --
@@ -1392,13 +1416,12 @@ abstract class McpProxyItemFactory implements BindingHandler
         // as raw verbatim bytes straight out of cache.toolsBytes(), never a DOM rebuild; the full
         // definition (schema included) is resolved separately via describe_tool.
         private byte[] buildResponse(
-            String query,
+            List<McpToolSearchMatch> matches,
             int limit)
         {
             final Map<CharSequence, List<String>> scopesByName = cache.scopesByName();
             final Map<CharSequence, McpToolByteRange> rangesByName = cache.toolRangesByName();
             final byte[] toolsBytes = cache.toolsBytes();
-            final List<McpToolSearchMatch> matches = cache.searchIndex().query(query);
 
             final int structuredLength = writeStructuredContent(matches, scopesByName, rangesByName, toolsBytes, limit);
             final int responseLength = writeSearchFamilyResponse(structuredLength);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
@@ -142,7 +142,7 @@ public final class McpProxyCache
         if (filter.test(KIND_TOOLS_LIST))
         {
             final McpToolSearchIndex searchIndex = cache.tools != null
-                ? new McpToolSearchIndexFactory().create(cache.tools.search)
+                ? new McpToolSearchIndexFactory().create(context, cache.tools.search)
                 : null;
             final List<String> searchFields = cache.tools != null && cache.tools.search != null
                 ? cache.tools.search.fields
@@ -545,12 +545,48 @@ public final class McpProxyCache
             {
                 final List<McpToolSearchDocument> documents = McpToolSearchDocumentScanner.scan(value, searchFields);
                 descriptionsByName = indexDescriptionsByName(documents);
-                searchIndex.index(documents);
                 toolsBytes = value.getBytes(StandardCharsets.UTF_8);
                 toolRangesByName = McpToolByteRangeScanner.scan(toolsBytes);
+                searchIndex.index(documents, settled(ex -> putToStore(value, changed, completion)));
             }
+            else
+            {
+                putToStore(value, changed, completion);
+            }
+        }
+
+        private void putToStore(
+            String value,
+            boolean changed,
+            Consumer<String> completion)
+        {
             store.put(storeKey, value, STORE_TTL_FOREVER, completion.andThen(this::checkPut)
                 .andThen(k -> onSettled.accept(kind, changed, value)));
+        }
+
+        // the only backend today (keyword) never fails to index, so both outcomes take the same
+        // action here; a backend that can genuinely fail (e.g. an unavailable embedding provider)
+        // still proceeds to store the tools list rather than blocking it on search availability --
+        // stale/incomplete search results until the next successful rebuild, not a lost cache write
+        private McpToolSearchIndex.CompletionCallback<Void> settled(
+            Consumer<Throwable> completion)
+        {
+            return new McpToolSearchIndex.CompletionCallback<>()
+            {
+                @Override
+                public void completed(
+                    Void result)
+                {
+                    completion.accept(null);
+                }
+
+                @Override
+                public void failed(
+                    Throwable ex)
+                {
+                    completion.accept(ex);
+                }
+            };
         }
 
         public void acquire(
@@ -593,28 +629,37 @@ public final class McpProxyCache
             String key,
             String value)
         {
-            final boolean changed;
             if (value != null)
             {
                 crc32.reset();
                 crc32.update(value.getBytes(StandardCharsets.UTF_8));
                 final long newChecksum = crc32.getValue();
-                changed = lastChecksum != -1L && lastChecksum != newChecksum;
+                final boolean changed = lastChecksum != -1L && lastChecksum != newChecksum;
                 lastChecksum = newChecksum;
                 scopesByName = indexScopesByName(value);
                 if (searchIndex != null)
                 {
                     final List<McpToolSearchDocument> documents = McpToolSearchDocumentScanner.scan(value, searchFields);
                     descriptionsByName = indexDescriptionsByName(documents);
-                    searchIndex.index(documents);
                     toolsBytes = value.getBytes(StandardCharsets.UTF_8);
                     toolRangesByName = McpToolByteRangeScanner.scan(toolsBytes);
+                    searchIndex.index(documents, settled(ex -> finishCheckGet(value, changed)));
+                }
+                else
+                {
+                    finishCheckGet(value, changed);
                 }
             }
             else
             {
-                changed = false;
+                finishCheckGet(null, false);
             }
+        }
+
+        private void finishCheckGet(
+            String value,
+            boolean changed)
+        {
             populated = value != null;
             checkReady();
             onSettled.accept(kind, changed, value);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/search/McpToolSearchIndex.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/search/McpToolSearchIndex.java
@@ -21,7 +21,16 @@ import java.util.List;
  * A ranking backend behind {@code options.cache.tools.search}.
  * <p>
  * Instances are single-threaded, owned by the worker that rebuilds and queries the warm
- * tool-search index; {@link #index(Collection)} replaces the prior contents entirely.
+ * tool-search index; {@link #index(Collection, CompletionCallback)} replaces the prior
+ * contents entirely.
+ * </p>
+ * <p>
+ * <b>Both operations complete asynchronously, always.</b> {@code completed} fires
+ * <em>strictly later</em> than the call returns — never on the caller's stack, even when an
+ * implementation can decide inline (e.g. a purely in-memory ranking backend). Implementations
+ * defer delivery by at least one tick, typically via {@code EngineContext.dispatch}, so a
+ * caller composing multiple backends (see {@code McpToolSearchComposite}) never has to handle
+ * a reentrant completion.
  * </p>
  */
 public interface McpToolSearchIndex
@@ -30,21 +39,50 @@ public interface McpToolSearchIndex
      * Rebuilds the index from the current warm catalog.
      *
      * @param documents  the full set of searchable tool documents
+     * @param completed  invoked once the index has been rebuilt, or has failed to rebuild
      */
     void index(
-        Collection<McpToolSearchDocument> documents);
+        Collection<McpToolSearchDocument> documents,
+        CompletionCallback<Void> completed);
 
     /**
      * Ranks every indexed document against the given query text.
      * <p>
-     * Returns every document with a non-zero match, sorted by descending relevance, with no
-     * limit applied — callers apply {@code limit} after any additional filtering (e.g.
-     * per-session authorization).
+     * On success, {@code completed} receives every document with a non-zero match, sorted by
+     * descending relevance, with no limit applied — callers apply {@code limit} after any
+     * additional filtering (e.g. per-session authorization).
      * </p>
      *
-     * @param text  the query text
-     * @return matches sorted by descending relevance; empty if nothing matches
+     * @param text       the query text
+     * @param completed  invoked with matches sorted by descending relevance (empty if nothing
+     *                   matches), or with the failure if ranking could not complete
      */
-    List<McpToolSearchMatch> query(
-        String text);
+    void query(
+        String text,
+        CompletionCallback<List<McpToolSearchMatch>> completed);
+
+    /**
+     * Completion handler for the asynchronous operations on this interface, modelled after
+     * {@link java.nio.channels.CompletionHandler}.
+     *
+     * @param <V> the result type
+     */
+    interface CompletionCallback<V>
+    {
+        /**
+         * Invoked when the operation completes successfully.
+         *
+         * @param result  the operation result
+         */
+        void completed(
+            V result);
+
+        /**
+         * Invoked when the operation fails.
+         *
+         * @param ex  the failure cause
+         */
+        void failed(
+            Throwable ex);
+    }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/search/McpToolSearchIndexFactorySpi.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/search/McpToolSearchIndexFactorySpi.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.aklivity.zilla.config.binding.mcp.McpToolSearchIndexConfig;
+import io.aklivity.zilla.runtime.engine.EngineContext;
 
 /**
  * Service provider interface for a pluggable {@link McpToolSearchIndex} implementation.
@@ -43,12 +44,15 @@ public interface McpToolSearchIndexFactorySpi
     /**
      * Creates a new {@link McpToolSearchIndex} instance for the given indexer configuration.
      *
+     * @param context  the engine context, e.g. for {@code EngineContext.dispatch} or resolving
+     *                 other named engine concepts a backend depends on
      * @param config   the type-specific indexer configuration
      * @param fields   the shared list of document fields to index, in configuration order
      * @param weights  the shared per-field relative importance, keyed by field name
      * @return a new index instance
      */
     McpToolSearchIndex create(
+        EngineContext context,
         McpToolSearchIndexConfig config,
         List<String> fields,
         Map<String, Double> weights);

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndexTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndexTest.java
@@ -21,13 +21,16 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
+import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchDocument;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex.CompletionCallback;
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
 
 public class McpKeywordToolSearchIndexTest
@@ -37,33 +40,33 @@ public class McpKeywordToolSearchIndexTest
     @Test
     public void shouldReturnEmptyForNoDocuments()
     {
-        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(FIELDS, Map.of());
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(Runnable::run, FIELDS, Map.of());
 
-        index.index(List.of());
+        rebuild(index, List.of());
 
-        assertThat(index.query("kafka"), empty());
+        assertThat(search(index, "kafka"), empty());
     }
 
     @Test
     public void shouldReturnEmptyWhenNoMatch()
     {
-        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(FIELDS, Map.of());
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(Runnable::run, FIELDS, Map.of());
 
-        index.index(List.of(document("github_create_pr", "create pr", "opens a pull request")));
+        rebuild(index, List.of(document("github_create_pr", "create pr", "opens a pull request")));
 
-        assertThat(index.query("kafka"), empty());
+        assertThat(search(index, "kafka"), empty());
     }
 
     @Test
     public void shouldMatchExactTermInName()
     {
-        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(FIELDS, Map.of());
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(Runnable::run, FIELDS, Map.of());
 
-        index.index(List.of(
+        rebuild(index, List.of(
             document("github_create_pr", "github create pr", "opens a pull request"),
             document("kafka_list_topics", "kafka list topics", "lists kafka topics")));
 
-        List<McpToolSearchMatch> matches = index.query("kafka");
+        List<McpToolSearchMatch> matches = search(index, "kafka");
 
         assertThat(matches, not(empty()));
         assertThat(matches.get(0).name, equalTo("kafka_list_topics"));
@@ -73,13 +76,13 @@ public class McpKeywordToolSearchIndexTest
     public void shouldRankHigherWeightFieldHigher()
     {
         Map<String, Double> weights = Map.of("name", 3.0, "description", 1.0);
-        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(FIELDS, weights);
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(Runnable::run, FIELDS, weights);
 
-        index.index(List.of(
+        rebuild(index, List.of(
             document("kafka_tool", "kafka topic manager", "manages message queues"),
             document("other_tool", "generic manager", "manages kafka message queues")));
 
-        List<McpToolSearchMatch> matches = index.query("kafka");
+        List<McpToolSearchMatch> matches = search(index, "kafka");
 
         assertThat(matches, hasSize(2));
         assertThat(matches.get(0).name, equalTo("kafka_tool"));
@@ -89,11 +92,11 @@ public class McpKeywordToolSearchIndexTest
     @Test
     public void shouldFindTermInsideCamelCaseCompoundToken()
     {
-        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(FIELDS, Map.of());
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(Runnable::run, FIELDS, Map.of());
 
-        index.index(List.of(document("createKafkaTopic", "createKafkaTopic", null)));
+        rebuild(index, List.of(document("createKafkaTopic", "createKafkaTopic", null)));
 
-        List<McpToolSearchMatch> matches = index.query("kafka");
+        List<McpToolSearchMatch> matches = search(index, "kafka");
 
         assertThat(matches, hasSize(1));
         assertThat(matches.get(0).name, equalTo("createKafkaTopic"));
@@ -102,18 +105,100 @@ public class McpKeywordToolSearchIndexTest
     @Test
     public void shouldReturnResultsSortedByScoreDescending()
     {
-        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(FIELDS, Map.of());
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(Runnable::run, FIELDS, Map.of());
 
-        index.index(List.of(
+        rebuild(index, List.of(
             document("weak_match", "list resources", "kafka appears once here"),
             document("strong_match", "kafka kafka kafka", "kafka topic tool"),
             document("no_match", "unrelated tool", "does something else entirely")));
 
-        List<McpToolSearchMatch> matches = index.query("kafka");
+        List<McpToolSearchMatch> matches = search(index, "kafka");
 
         assertThat(matches, hasSize(2));
         assertThat(matches.get(0).name, equalTo("strong_match"));
         assertThat(matches.get(0).score, greaterThan(matches.get(1).score));
+    }
+
+    @Test
+    public void shouldNeverCompleteOnTheCallingStack()
+    {
+        Queue<Runnable> dispatched = new ArrayDeque<>();
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(dispatched::add, FIELDS, Map.of());
+        boolean[] completed = { false };
+
+        index.index(
+            List.of(document("kafka_tool", "kafka topic manager", "manages kafka topics")),
+            new CompletionCallback<Void>()
+            {
+                @Override
+                public void completed(
+                    Void result)
+                {
+                    completed[0] = true;
+                }
+
+                @Override
+                public void failed(
+                    Throwable ex)
+                {
+                    throw new AssertionError(ex);
+                }
+            });
+
+        assertThat(completed[0], equalTo(false));
+
+        dispatched.poll().run();
+
+        assertThat(completed[0], equalTo(true));
+    }
+
+    private static void rebuild(
+        McpKeywordToolSearchIndex index,
+        List<McpToolSearchDocument> documents)
+    {
+        boolean[] done = { false };
+        index.index(documents, new CompletionCallback<Void>()
+        {
+            @Override
+            public void completed(
+                Void result)
+            {
+                done[0] = true;
+            }
+
+            @Override
+            public void failed(
+                Throwable ex)
+            {
+                throw new AssertionError(ex);
+            }
+        });
+        assertThat(done[0], equalTo(true));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<McpToolSearchMatch> search(
+        McpKeywordToolSearchIndex index,
+        String text)
+    {
+        Object[] result = new Object[1];
+        index.query(text, new CompletionCallback<List<McpToolSearchMatch>>()
+        {
+            @Override
+            public void completed(
+                List<McpToolSearchMatch> matches)
+            {
+                result[0] = matches;
+            }
+
+            @Override
+            public void failed(
+                Throwable ex)
+            {
+                throw new AssertionError(ex);
+            }
+        });
+        return (List<McpToolSearchMatch>) result[0];
     }
 
     private static McpToolSearchDocument document(

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchCompositeTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchCompositeTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchDocument;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
+
+public class McpToolSearchCompositeTest
+{
+    @Test
+    public void shouldWaitForAllBackendsBeforeCompletingIndex()
+    {
+        FakeIndex first = new FakeIndex();
+        FakeIndex second = new FakeIndex();
+        McpToolSearchComposite composite = new McpToolSearchComposite(List.of(first, second));
+        int[] completions = { 0 };
+
+        composite.index(List.of(), new McpToolSearchIndex.CompletionCallback<Void>()
+        {
+            @Override
+            public void completed(
+                Void result)
+            {
+                completions[0]++;
+            }
+
+            @Override
+            public void failed(
+                Throwable ex)
+            {
+                throw new AssertionError(ex);
+            }
+        });
+
+        assertThat(completions[0], equalTo(0));
+
+        first.completeIndex();
+        assertThat(completions[0], equalTo(0));
+
+        second.completeIndex();
+        assertThat(completions[0], equalTo(1));
+    }
+
+    @Test
+    public void shouldFuseResultsFromAllBackendsRegardlessOfCompletionOrder()
+    {
+        FakeIndex first = new FakeIndex();
+        FakeIndex second = new FakeIndex();
+        McpToolSearchComposite composite = new McpToolSearchComposite(List.of(first, second));
+        List<McpToolSearchMatch>[] fused = new List[1];
+
+        composite.query("kafka", new McpToolSearchIndex.CompletionCallback<List<McpToolSearchMatch>>()
+        {
+            @Override
+            public void completed(
+                List<McpToolSearchMatch> matches)
+            {
+                fused[0] = matches;
+            }
+
+            @Override
+            public void failed(
+                Throwable ex)
+            {
+                throw new AssertionError(ex);
+            }
+        });
+
+        // completes out of order -- second backend settles before first
+        second.completeQuery(List.of(new McpToolSearchMatch("b", 9.0)));
+        assertThat(fused[0], equalTo(null));
+
+        first.completeQuery(List.of(new McpToolSearchMatch("a", 9.0)));
+
+        assertThat(names(fused[0]), contains("a", "b"));
+    }
+
+    @Test
+    public void shouldForwardFirstFailureExactlyOnce()
+    {
+        FakeIndex first = new FakeIndex();
+        FakeIndex second = new FakeIndex();
+        McpToolSearchComposite composite = new McpToolSearchComposite(List.of(first, second));
+        RuntimeException failure = new RuntimeException("embedding provider unavailable");
+        int[] failures = { 0 };
+
+        composite.query("kafka", new McpToolSearchIndex.CompletionCallback<List<McpToolSearchMatch>>()
+        {
+            @Override
+            public void completed(
+                List<McpToolSearchMatch> matches)
+            {
+                throw new AssertionError("expected failure, not " + matches);
+            }
+
+            @Override
+            public void failed(
+                Throwable ex)
+            {
+                assertThat(ex, sameInstance(failure));
+                failures[0]++;
+            }
+        });
+
+        first.failQuery(failure);
+        second.completeQuery(List.of());
+
+        assertThat(failures[0], equalTo(1));
+    }
+
+    @Test
+    public void shouldDelegateDirectlyForSingleBackend()
+    {
+        FakeIndex only = new FakeIndex();
+        McpToolSearchComposite composite = new McpToolSearchComposite(List.of(only));
+        McpToolSearchIndex.CompletionCallback<List<McpToolSearchMatch>> callback =
+            new McpToolSearchIndex.CompletionCallback<List<McpToolSearchMatch>>()
+            {
+                @Override
+                public void completed(
+                    List<McpToolSearchMatch> matches)
+                {
+                }
+
+                @Override
+                public void failed(
+                    Throwable ex)
+                {
+                }
+            };
+
+        composite.query("kafka", callback);
+
+        assertThat(only.queryCallback, sameInstance(callback));
+    }
+
+    private static List<String> names(
+        List<McpToolSearchMatch> matches)
+    {
+        return matches.stream().map(match -> match.name).collect(Collectors.toList());
+    }
+
+    private static final class FakeIndex implements McpToolSearchIndex
+    {
+        private CompletionCallback<Void> indexCallback;
+        private CompletionCallback<List<McpToolSearchMatch>> queryCallback;
+
+        @Override
+        public void index(
+            Collection<McpToolSearchDocument> documents,
+            CompletionCallback<Void> completed)
+        {
+            this.indexCallback = completed;
+        }
+
+        @Override
+        public void query(
+            String text,
+            CompletionCallback<List<McpToolSearchMatch>> completed)
+        {
+            this.queryCallback = completed;
+        }
+
+        private void completeIndex()
+        {
+            indexCallback.completed(null);
+        }
+
+        private void completeQuery(
+            List<McpToolSearchMatch> matches)
+        {
+            queryCallback.completed(matches);
+        }
+
+        private void failQuery(
+            Throwable ex)
+        {
+            queryCallback.failed(ex);
+        }
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchIndexFactoryTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchIndexFactoryTest.java
@@ -19,6 +19,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
 import java.util.List;
@@ -31,15 +34,29 @@ import io.aklivity.zilla.config.binding.mcp.McpKeywordToolSearchIndexConfig;
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchDocument;
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
+import io.aklivity.zilla.runtime.engine.EngineContext;
 
 public class McpToolSearchIndexFactoryTest
 {
+    // dispatches inline -- fine for a unit test asserting ranking behavior, not timing;
+    // McpKeywordToolSearchIndexTest.shouldNeverCompleteOnTheCallingStack covers the
+    // "never on the caller's stack" contract itself
+    private final EngineContext context = mock(EngineContext.class);
     private final McpToolSearchIndexFactory factory = new McpToolSearchIndexFactory();
+
+    public McpToolSearchIndexFactoryTest()
+    {
+        doAnswer(invocation ->
+        {
+            ((Runnable) invocation.getArgument(0)).run();
+            return null;
+        }).when(context).dispatch(any());
+    }
 
     @Test
     public void shouldReturnNullWhenSearchNotConfigured()
     {
-        assertThat(factory.create(null), nullValue());
+        assertThat(factory.create(context, null), nullValue());
     }
 
     @Test
@@ -50,7 +67,7 @@ public class McpToolSearchIndexFactoryTest
             .fields(List.of("name", "description"))
             .build();
 
-        assertThat(factory.create(search), nullValue());
+        assertThat(factory.create(context, search), nullValue());
     }
 
     @Test
@@ -62,12 +79,12 @@ public class McpToolSearchIndexFactoryTest
             .index(McpKeywordToolSearchIndexConfig.builder().build())
             .build();
 
-        McpToolSearchIndex index = factory.create(search);
+        McpToolSearchIndex index = factory.create(context, search);
 
         assertThat(index, not(nullValue()));
 
-        index.index(List.of(document("kafka_tool", "kafka topic manager", "manages kafka topics")));
-        List<McpToolSearchMatch> matches = index.query("kafka");
+        rebuild(index, List.of(document("kafka_tool", "kafka topic manager", "manages kafka topics")));
+        List<McpToolSearchMatch> matches = search(index, "kafka");
 
         assertThat(matches, hasSize(1));
         assertThat(matches.get(0).name, equalTo("kafka_tool"));
@@ -83,15 +100,64 @@ public class McpToolSearchIndexFactoryTest
             .index(McpKeywordToolSearchIndexConfig.builder().build())
             .build();
 
-        McpToolSearchIndex index = factory.create(search);
+        McpToolSearchIndex index = factory.create(context, search);
 
-        index.index(List.of(
+        rebuild(index, List.of(
             document("kafka_tool", "kafka topic manager", "manages kafka topics"),
             document("other_tool", "generic manager", "does something unrelated")));
-        List<McpToolSearchMatch> matches = index.query("kafka");
+        List<McpToolSearchMatch> matches = search(index, "kafka");
 
         assertThat(matches, hasSize(1));
         assertThat(matches.get(0).name, equalTo("kafka_tool"));
+    }
+
+    private static void rebuild(
+        McpToolSearchIndex index,
+        List<McpToolSearchDocument> documents)
+    {
+        boolean[] done = { false };
+        index.index(documents, new McpToolSearchIndex.CompletionCallback<Void>()
+        {
+            @Override
+            public void completed(
+                Void result)
+            {
+                done[0] = true;
+            }
+
+            @Override
+            public void failed(
+                Throwable ex)
+            {
+                throw new AssertionError(ex);
+            }
+        });
+        assertThat(done[0], equalTo(true));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<McpToolSearchMatch> search(
+        McpToolSearchIndex index,
+        String text)
+    {
+        Object[] result = new Object[1];
+        index.query(text, new McpToolSearchIndex.CompletionCallback<List<McpToolSearchMatch>>()
+        {
+            @Override
+            public void completed(
+                List<McpToolSearchMatch> matches)
+            {
+                result[0] = matches;
+            }
+
+            @Override
+            public void failed(
+                Throwable ex)
+            {
+                throw new AssertionError(ex);
+            }
+        });
+        return (List<McpToolSearchMatch>) result[0];
     }
 
     private static McpToolSearchDocument document(


### PR DESCRIPTION
## Description

`McpToolSearchIndex.index()`/`query()` (the interface a `McpToolSearchIndexFactorySpi` ranking backend implements, behind `options.cache.tools.search`) were synchronous-only — plain methods returning a value directly. A ranking backend that needs to resolve something asynchronously as part of building or querying its index (for example, a lookup against another async engine concept) has no way to implement this contract without blocking the engine worker, which the engine's threading model forbids.

This PR makes both methods callback-based instead, matching the "completes asynchronously, always — never on the caller's stack" contract the engine's other async SPIs already provide (`StoreHandler`, the async `GuardHandler.reauthorize`). Every implementation, including the shipped `keyword` backend, defers its completion via `EngineContext.dispatch()` rather than ever completing inline. This is deliberate even though `keyword` itself never needs to be async: it means `McpToolSearchComposite` (which fuses however many backends are configured via Reciprocal Rank Fusion) is exercised against genuine async timing from day one, rather than only once a real async backend happens to be registered — a backend that completes inline today would let a latent ordering bug in the composite's join logic go unnoticed until then.

`McpToolSearchIndexFactorySpi.create(...)` now also receives the engine context, so a backend implementation can dispatch onto the correct worker or resolve whatever other named engine concepts it depends on — the same context every other binding-level factory already receives.

No `zilla.yaml` config shape, JSON schema, or wire-visible protocol behavior changes here — this is a pure internal SPI change, scoped entirely to `binding-mcp`, with a single in-tree consumer (`keyword`) updated to match.

## What changed

- `McpToolSearchIndex.index()`/`query()` take a `CompletionCallback<V>` instead of returning a value.
- `McpToolSearchIndexFactorySpi.create(...)` gains an `EngineContext` parameter.
- `McpKeywordToolSearchIndex` defers its (still synchronous, CPU-bound) completion via `EngineContext.dispatch()`.
- `McpToolSearchComposite` fans an `index()`/`query()` call out to every configured backend and joins once all have completed, forwarding the first failure reported by any backend as its own; a single configured backend still delegates directly, with no fan-in overhead.
- The two runtime call sites (`McpProxyCache`'s tools-list rebuild, `McpProxyItemFactory`'s search-tool-call response) are restructured to continue past the async completion rather than the previous inline call.

## Test plan

- [x] New `McpToolSearchCompositeTest` covering the join itself: waiting for all backends before completing, fusing results that arrive out of order, forwarding a single failure exactly once (not once per failing backend), and the single-backend delegate-directly path.
- [x] `McpKeywordToolSearchIndexTest` gains `shouldNeverCompleteOnTheCallingStack`, asserting the completion genuinely doesn't fire until the dispatched task is run.
- [x] Existing `McpKeywordToolSearchIndexTest`/`McpToolSearchIndexFactoryTest` cases updated to the callback shape; ranking-correctness assertions unchanged.
- [x] `./mvnw -pl runtime/binding-mcp clean verify` green: 201 unit tests, 313 k3po ITs (including the existing `tools/search` scenarios in `McpProxyCacheIT`), checkstyle 0 violations, JaCoCo coverage checks met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GD1PunXvfUv4Y69nB6YDUY)_