### PR TITLE
feat(vault-filesystem): graduate secrets options out of incubating

### DIFF
--- a/specs/vault-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/vault/filesystem/schema/filesystem.schema.patch.json
+++ b/specs/vault-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/vault/filesystem/schema/filesystem.schema.patch.json
@@ -127,7 +127,6 @@
                             "secrets":
                             {
                                 "title": "Secrets",
-                                "x-incubating": true,
                                 "type": "object",
                                 "properties":
                                 {


### PR DESCRIPTION
## Description

Removes the `x-incubating: true` schema annotation from the `secrets`
(`SecretKeyEntry`) options block in the filesystem vault's schema patch
(`specs/vault-filesystem.spec/.../schema/filesystem.schema.patch.json`).

`x-incubating` is stripped from the aggregated `zilla.yaml` schema by
`EngineConfigReader` whenever incubator mode is off (i.e. in a tagged
release, unless `zilla.incubator.enabled` is set), which currently hides
the `secrets` options object from users running a released build. This
change graduates `secrets` to the same non-gated status as its sibling
options (`keys`, `trust`, `signers`), so it validates and is usable in
release builds without the incubator flag.

No behavioral/runtime code changes — this is a schema-patch-only change.

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SNq14TQPU8zRxYU1KepJHQ)_