### PR TITLE
feat(binding-kafka): stream value transforms directly into the cache, delete convertedFile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,22 @@ private void onNetworkData(
   `cleanupDecodeSlotIfNecessary`) — name methods for what they do (`doEnd`,
   `cleanupDecodeSlot`); internal conditionality based on stream state or slot
   value is an implementation detail that does not belong in the name
+- Name fields, parameters, and locals for the role they play in production,
+  not for how they feel to write. Avoid names that read as placeholder or
+  debug scaffolding (`scratch`, `tmp`, `foo`, `data2`) — even a reusable
+  buffer with no domain meaning of its own needs a name describing its role
+  (e.g. `transformBuffer`, not `scratch`). Equally, avoid names so verbose
+  they restate the type or the enclosing class (`kafkaCacheModelTransformer`
+  inside `KafkaCacheModel`, `httpServerFactoryFlyweightBuffer` as a field on
+  `HttpServerFactory`) — once the surrounding type and class already carry
+  that meaning, repeating it in the name is noise, not clarity. A short,
+  precise name beats both extremes
+- Prefer self-describing code — clear names and small, well-named methods —
+  over comments that explain what the code does. Default to no comment; add
+  one only when removing it would lose a non-obvious WHY that the code itself
+  cannot express (a hidden constraint, a workaround for a specific bug, a
+  subtle invariant). The license header is the only comment every file
+  requires
 - Java 21; no preview features
 - No Lombok
 - Use `jakarta.json` APIs (e.g., `JsonObject`, `JsonReader`, `JsonParser`)

--- a/runtime/binding-kafka/AGENTS.md
+++ b/runtime/binding-kafka/AGENTS.md
@@ -21,54 +21,52 @@ downstream clients without additional round-trips to Kafka.
 
 ---
 
-## KafkaPipeline — whole-message composition
+## KafkaCacheModel — incremental key/value transforms
 
-`KafkaPipeline` sits one layer above the engine's `ModelPipeline`. It owns the
-key's model pipeline and the value's model pipeline, drives each in turn, and
-translates their per-field output into `KafkaEvent` — a lane selector
-(`SWITCH_KEY` / `SWITCH_HEADERS` / `SWITCH_VALUE`) plus one shared `FIELD`.
-`KafkaTransform` stages compose with `andThen` and append to any lane at the
-moment they have something to append; `KafkaExtractTransform` is one stage per
-`extractKey` / `extractHeaders` config entry.
+`KafkaCacheModel` wraps the engine's `ModelPipeline` for a cache entry's key or
+value, driven once per DATA fragment via `transform(traceId, bindingId,
+authorization, flags, data, index, limit, Output)` — `flags` are the caller's
+own frame `FLAGS_INIT` / `FLAGS_FIN`, passed straight through. It reports back
+via a reused `Result`: `UNDERFLOW` (more fragments expected, pipeline state
+retained), `COMPLETE` (value finished this fragment, pipeline reset), or
+`REJECTED` (validation failure, pipeline reset, caller aborts the entry). A
+whole-value convenience overload (used by non-streaming callers) delegates
+with both flags set. `KafkaCacheModel.NONE` is a plain passthrough.
 
-Two rules the terminal `KafkaSink` depends on:
+An optional `ModelTransform` composes with the model's own pipeline via
+`andThen`; `KafkaExtractTransform` is the one shipped implementation, one
+instance per `extractKey` / `extractHeaders` config entry. It observes a field
+at a configured path and copies its value into a `ModelEnvelope` under a
+configured name — the field itself still flows through to the model's own
+output untouched, so the stage is always identity. `extractKey` writes into a
+`KafkaCacheKeyEnvelope` (`KafkaCachePartition` reads the override back off it
+in place of the persisted key); `extractHeaders` writes into a
+`KafkaCacheTrailerEnvelope` (read back as the entry's `trailers`).
 
-- A lane switch selects the destination of the **single** `FIELD` that follows
-  it. A field with no switch ahead of it is one the traversal merely surfaced
-  and nothing is written for it.
-- The pipeline's opening announcement of the lane it is traversing reaches the
-  stages but **not** the terminal. Without that, `extractKey` — whose origin
-  and target are both the key lane — cannot be told apart from the key's own
-  fields flowing past.
+## Write protocol: reserve, stream, finalize
 
-## Supported lane transitions
+Both the produce path (`KafkaCacheClientProduceFactory`) and the populate path
+(`KafkaCacheServerFetchFactory`) write a cache entry in three calls —
+`write*EntryStart` / `write*EntryContinue` / `write*Fin`/`write*Finish` — that
+reserve a region up front and then either fill it in place or, if the real
+content ends up smaller than the reservation, finalize a `length`/`paddingLen`
+pair to describe the leftover. `KafkaCachePaddedKey`/`KafkaCachePaddedValue`
+(the `paddedKey`/`paddedValue` fields on `KafkaCacheEntry`) both follow this
+shape natively: `length` + the field's own bytes + `paddingLen` + padding
+octets, with `paddingLen` relocated to sit right after the real (possibly
+transformed) length once it's known — `commitKeyOverride` does this for a key,
+`writeEntryContinue`/`writeProduceEntryContinue` do it for a value's COMPLETE
+transition.
 
-The vocabulary can express a stage appending to any lane from any lane, but only
-two combinations have somewhere to land in the cache entry's layout:
-
-| traversing | may append to | why not the others |
-| --- | --- | --- |
-| key | key (`extractKey`) | no trailers are under construction during the key drive |
-| value | headers (`extractHeaders`) | the key's hash is already computed and indexed by then |
-
-Nothing can be appended to the value lane at all — the value's bytes come from
-its model's output, not from `KafkaEvent`. A stage reaching for any unsupported
-transition trips an `assert` in `KafkaPipeline.KafkaLaneGuard` rather than being
-silently dropped by the terminal, and a stage that appends during the pipeline's
-opening lane announcement trips the `assert` in `KafkaPipeline.ANNOUNCE`. Relax
-these only as a deliberate move to fully parallel key, headers, and value
-writes.
-
-No `extractKey` / `extractHeaders` configuration can reach an unsupported
-transition, so `KafkaPipelineTest` drives them through
-`KafkaPipeline.stagedDecoder`, a package-private factory over an explicit stage
-chain.
-
-The key lane is the one place content is not written the instant it is found:
-its destination is the key itself, still being appended by the key's own model
-when the match arrives, and `KafkaCacheFile` only grows forward. The extracted
-key waits in a single slot in `KafkaCachePartition.KafkaEntrySink` until the
-key region is closed. Headers stream with no buffering at all.
-
-Extracted headers land in field-encounter order, not `extractHeaders` config
-order — a direct consequence of the streaming design.
+A value transform's output streams directly into the `paddedValue`
+reservation as fragments arrive — plaintext never touches the log file when a
+value model is configured. When a value model additionally composes an
+`extractHeaders` stage, its `KafkaCacheTrailerEnvelope` must be claimed before
+the first fragment is driven (fragments arrive well before headers are known
+on the populate path), so `writeEntryStart` reserves a combined
+headers-worst-case + trailers-sized block up front and reuses the
+trailers-sized portion as the envelope's scratch space during the drive;
+`writeEntryFinish` later writes the real (smaller) headers and trailers
+contiguously over those same bytes and folds whatever remains into the
+entry's own trailing `paddingLen`/`padding` fields. The produce path doesn't
+need this reordering since it already knows its headers at `Start`.

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCursorFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCursorFactory.java
@@ -51,17 +51,13 @@ import io.aklivity.zilla.runtime.binding.kafka.internal.types.KafkaValueMatchFW;
 import io.aklivity.zilla.runtime.binding.kafka.internal.types.OctetsFW;
 import io.aklivity.zilla.runtime.binding.kafka.internal.types.cache.KafkaCacheDeltaFW;
 import io.aklivity.zilla.runtime.binding.kafka.internal.types.cache.KafkaCacheEntryFW;
-import io.aklivity.zilla.runtime.binding.kafka.internal.types.cache.KafkaCachePaddedValueFW;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public final class KafkaCacheCursorFactory
 {
-    private static final int NO_CONVERTED_POSITION = -1;
-
     private final KafkaCacheDeltaFW deltaRO = new KafkaCacheDeltaFW();
-    private final KafkaCachePaddedValueFW convertedRO = new KafkaCachePaddedValueFW();
     private final KafkaValueMatchFW valueMatchRO = new KafkaValueMatchFW();
     private final KafkaHeaderFW headerRO = new KafkaHeaderFW();
 
@@ -219,16 +215,9 @@ public final class KafkaCacheCursorFactory
                     nextEntry = null;
                 }
 
-                if (nextEntry != null)
+                if (nextEntry != null && deltaType != KafkaDeltaType.NONE)
                 {
-                    if (deltaType != KafkaDeltaType.NONE)
-                    {
-                        nextEntry = markAncestorIfNecessary(cacheEntry, nextEntry);
-                    }
-                    else if (nextEntry.convertedPosition() != NO_CONVERTED_POSITION)
-                    {
-                        nextEntry = nextConvertedEntry(cacheEntry, nextEntry);
-                    }
+                    nextEntry = markAncestorIfNecessary(cacheEntry, nextEntry);
                 }
 
                 if (nextEntry == null)
@@ -305,45 +294,6 @@ public final class KafkaCacheCursorFactory
                 deltaKeyOffsets.add(partitionOffset);
             }
             return nextEntry;
-        }
-
-        private KafkaCacheEntryFW nextConvertedEntry(
-            KafkaCacheEntryFW cacheEntry,
-            KafkaCacheEntryFW nextEntry)
-        {
-            final int convertedAt = nextEntry.convertedPosition();
-            assert convertedAt != NO_CONVERTED_POSITION;
-
-            final KafkaCacheFile convertedFile = segment.convertedFile();
-            final KafkaCachePaddedValueFW converted = convertedFile.readBytes(convertedAt, convertedRO::wrap);
-            final OctetsFW convertedValue = converted.value();
-            final DirectBufferEx entryBuffer = nextEntry.buffer();
-            final KafkaKeyFW key = nextEntry.paddedKey().key();
-            final int entryOffset = nextEntry.offset();
-            final ArrayFW<KafkaHeaderFW> headers = nextEntry.headers();
-            final ArrayFW<KafkaHeaderFW> trailers = nextEntry.trailers();
-
-            final int sizeofEntryHeader = key.limit() - nextEntry.offset();
-
-            int writeLimit = 0;
-            writeBuffer.putBytes(writeLimit, entryBuffer, entryOffset, sizeofEntryHeader);
-            writeLimit += sizeofEntryHeader;
-            writeBuffer.putInt(writeLimit, 0);
-            writeLimit += Integer.BYTES;
-            writeBuffer.putInt(writeLimit, convertedValue.sizeof());
-            writeLimit += Integer.BYTES;
-            writeBuffer.putBytes(writeLimit, convertedValue.buffer(), convertedValue.offset(), convertedValue.sizeof());
-            writeLimit += convertedValue.sizeof();
-            writeBuffer.putInt(writeLimit, 0);
-            writeLimit += Integer.BYTES;
-            writeBuffer.putBytes(writeLimit, headers.buffer(), headers.offset(), headers.sizeof());
-            writeLimit += headers.sizeof();
-            writeBuffer.putBytes(writeLimit, trailers.buffer(), trailers.offset(), trailers.sizeof());
-            writeLimit += trailers.sizeof();
-            writeBuffer.putInt(writeLimit, 0);
-            writeLimit += Integer.BYTES;
-
-            return cacheEntry.wrap(writeBuffer, 0, writeLimit);
         }
 
         public void advance(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCursorFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCursorFactory.java
@@ -251,7 +251,7 @@ public final class KafkaCacheCursorFactory
         {
             final long ancestorOffset = nextEntry.ancestor();
 
-            if (nextEntry.valueLen() == -1)
+            if (nextEntry.paddedValue().length() == -1)
             {
                 deltaKeyOffsets.remove(ancestorOffset);
             }
@@ -281,6 +281,8 @@ public final class KafkaCacheCursorFactory
                         writeLimit += Integer.BYTES;
                         writeBuffer.putBytes(writeLimit, delta.buffer(), delta.offset(), delta.sizeof());
                         writeLimit += delta.sizeof();
+                        writeBuffer.putInt(writeLimit, 0);
+                        writeLimit += Integer.BYTES;
                         writeBuffer.putBytes(writeLimit, headers.buffer(), headers.offset(), headers.sizeof());
                         writeLimit += headers.sizeof();
                         writeBuffer.putBytes(writeLimit, trailers.buffer(), trailers.offset(), trailers.sizeof());
@@ -332,6 +334,8 @@ public final class KafkaCacheCursorFactory
             writeLimit += Integer.BYTES;
             writeBuffer.putBytes(writeLimit, convertedValue.buffer(), convertedValue.offset(), convertedValue.sizeof());
             writeLimit += convertedValue.sizeof();
+            writeBuffer.putInt(writeLimit, 0);
+            writeLimit += Integer.BYTES;
             writeBuffer.putBytes(writeLimit, headers.buffer(), headers.offset(), headers.sizeof());
             writeLimit += headers.sizeof();
             writeBuffer.putBytes(writeLimit, trailers.buffer(), trailers.offset(), trailers.sizeof());

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheFile.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheFile.java
@@ -41,7 +41,6 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 public class KafkaCacheFile implements AutoCloseable
 {
     private static final String EXT_LOG = ".log";
-    private static final String EXT_CONVERTED = ".converted";
     private static final String EXT_DELTA = ".delta";
     private static final String EXT_INDEX = ".index";
     private static final String EXT_HSCAN = ".hscan";
@@ -56,7 +55,6 @@ public class KafkaCacheFile implements AutoCloseable
 
     private static final String FORMAT_FILE = "%%019d%s";
     private static final String FORMAT_LOG_FILE = String.format(FORMAT_FILE, EXT_LOG);
-    private static final String FORMAT_CONVERTED_FILE = String.format(FORMAT_FILE, EXT_CONVERTED);
     private static final String FORMAT_DELTA_FILE = String.format(FORMAT_FILE, EXT_DELTA);
     private static final String FORMAT_INDEX_FILE = String.format(FORMAT_FILE, EXT_INDEX);
     private static final String FORMAT_HSCAN_FILE = String.format(FORMAT_FILE, EXT_HSCAN);
@@ -592,25 +590,6 @@ public class KafkaCacheFile implements AutoCloseable
             long baseOffset)
         {
             super(location.resolve(String.format(FORMAT_DELTA_FILE, baseOffset)));
-        }
-    }
-
-    public static final class Converted extends KafkaCacheFile
-    {
-        public Converted(
-            Path location,
-            long baseOffset,
-            int capacity,
-            MutableDirectBufferEx appendBuf)
-        {
-            super(location.resolve(String.format(FORMAT_CONVERTED_FILE, baseOffset)), capacity, appendBuf);
-        }
-
-        public Converted(
-            Path location,
-            long baseOffset)
-        {
-            super(location.resolve(String.format(FORMAT_CONVERTED_FILE, baseOffset)));
         }
     }
 }

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModel.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModel.java
@@ -16,6 +16,7 @@
 package io.aklivity.zilla.runtime.binding.kafka.internal.cache;
 
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.ExpandableArrayBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.engine.model.ModelCache;
 import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
@@ -41,8 +42,49 @@ public final class KafkaCacheModel
             int length);
     }
 
+    // the outcome of a single fragment-wise transform() call; COMPLETE and REJECTED both reset the
+    // pipeline and are terminal for the value, UNDERFLOW means the pipeline is still open and this
+    // fragment's unconsumed tail (if any) has already been retained internally for the next call
+    public static final class Result
+    {
+        private ModelStatus status;
+        private int consumed;
+        private int produced;
+
+        public ModelStatus status()
+        {
+            return status;
+        }
+
+        public int consumed()
+        {
+            return consumed;
+        }
+
+        public int produced()
+        {
+            return produced;
+        }
+
+        private Result set(
+            ModelStatus status,
+            int consumed,
+            int produced)
+        {
+            this.status = status;
+            this.consumed = consumed;
+            this.produced = produced;
+            return this;
+        }
+    }
+
     private final ModelPipeline pipeline;
     private final MutableDirectBufferEx scratch;
+    private final ExpandableArrayBufferEx carry;
+    private final Result result;
+
+    private boolean started;
+    private int carried;
 
     public static KafkaCacheModel decoder(
         ModelHandler handler,
@@ -98,6 +140,8 @@ public final class KafkaCacheModel
     {
         this.pipeline = null;
         this.scratch = null;
+        this.carry = new ExpandableArrayBufferEx();
+        this.result = new Result();
     }
 
     KafkaCacheModel(
@@ -106,8 +150,16 @@ public final class KafkaCacheModel
     {
         this.pipeline = pipeline;
         this.scratch = scratch;
+        this.carry = new ExpandableArrayBufferEx();
+        this.result = new Result();
     }
 
+    // whole-value convenience: presents data[index..limit) as the complete value in one call.
+    // NONE's pipeline-less branch is handled directly here rather than via the fragment-wise overload
+    // below, since NONE is a single shared instance called unconditionally (and concurrently, across
+    // worker threads) by every key transform whether or not a key model is configured -- routing it
+    // through the fragment-wise method's reused Result field would make that field genuinely shared
+    // mutable state across threads
     public int transform(
         long traceId,
         long bindingId,
@@ -117,7 +169,7 @@ public final class KafkaCacheModel
         int limit,
         Output next)
     {
-        int total;
+        final int total;
         if (pipeline == null)
         {
             final int length = limit - index;
@@ -126,46 +178,111 @@ public final class KafkaCacheModel
         }
         else
         {
-            total = 0;
+            final Result whole = transform(traceId, bindingId, authorization, FLAGS_INIT | FLAGS_FIN,
+                data, index, limit, next);
+            total = whole.status() == ModelStatus.REJECTED ? -1 : whole.produced();
+        }
+        return total;
+    }
+
+    // fragment-wise: flags are the caller's own DATA-frame FLAGS_INIT / FLAGS_FIN, so a value may be
+    // presented across any number of calls; every byte of data[index..limit) is absorbed by this call --
+    // a caller never sees or manages a carried-over tail, even when the pipeline underflows mid-value.
+    // Every caller of this overload must gate on != NONE first, as the whole-value overload above does
+    // for its own pipeline-less branch -- this method's Result is reused per instance, and NONE is a
+    // single instance shared across worker threads
+    public Result transform(
+        long traceId,
+        long bindingId,
+        long authorization,
+        int flags,
+        DirectBufferEx data,
+        int index,
+        int limit,
+        Output next)
+    {
+        final int inputLength = limit - index;
+        final Result outcome;
+        if (pipeline == null)
+        {
+            next.accept(data, index, inputLength);
+            outcome = result.set((flags & FLAGS_FIN) != 0 ? ModelStatus.COMPLETE : ModelStatus.UNDERFLOW,
+                inputLength, inputLength);
+        }
+        else
+        {
+            DirectBufferEx src = data;
             int srcAt = index;
-            int flags = FLAGS_INIT | FLAGS_FIN;
-            boolean done = false;
-            while (!done)
+            int srcLimit = limit;
+            if (carried > 0)
             {
-                final ModelPipelineResult result = pipeline.transform(traceId, bindingId, authorization, flags,
-                    data, srcAt, limit, scratch, 0, scratch.capacity());
-                final ModelStatus status = result.status();
-                final int produced = result.produced();
-                final int consumed = result.consumed();
+                carry.putBytes(carried, data, index, inputLength);
+                src = carry;
+                srcAt = 0;
+                srcLimit = carried + inputLength;
+                carried = 0;
+            }
+
+            int total = 0;
+            int callFlags = (started ? 0 : FLAGS_INIT) | (flags & FLAGS_FIN);
+            started = true;
+            ModelStatus finalStatus = null;
+            while (finalStatus == null)
+            {
+                final ModelPipelineResult step = pipeline.transform(traceId, bindingId, authorization, callFlags,
+                    src, srcAt, srcLimit, scratch, 0, scratch.capacity());
+                final ModelStatus status = step.status();
+                final int consumed = step.consumed();
+                final int produced = step.produced();
+
+                if (produced > 0)
+                {
+                    next.accept(scratch, 0, produced);
+                    total += produced;
+                }
 
                 if (status == ModelStatus.REJECTED)
                 {
-                    total = -1;
-                    done = true;
+                    pipeline.reset();
+                    started = false;
+                    finalStatus = ModelStatus.REJECTED;
+                }
+                else if (status == ModelStatus.COMPLETE)
+                {
+                    pipeline.reset();
+                    started = false;
+                    finalStatus = ModelStatus.COMPLETE;
+                }
+                else if (status == ModelStatus.UNDERFLOW && (callFlags & FLAGS_FIN) != 0)
+                {
+                    // contract violation: a FIN call must resolve to COMPLETE or REJECTED, never
+                    // UNDERFLOW -- every shipped pipeline maps an incomplete value under FIN to
+                    // REJECTED, so this defends against a non-compliant pipeline rather than a real path
+                    pipeline.reset();
+                    started = false;
+                    finalStatus = ModelStatus.REJECTED;
+                }
+                else if (status == ModelStatus.UNDERFLOW || consumed == 0 && produced == 0)
+                {
+                    final int tailAt = srcAt + consumed;
+                    final int tailLength = srcLimit - tailAt;
+                    if (tailLength > 0)
+                    {
+                        carry.putBytes(0, src, tailAt, tailLength);
+                    }
+                    carried = tailLength;
+                    finalStatus = ModelStatus.UNDERFLOW;
                 }
                 else
                 {
-                    if (produced > 0)
-                    {
-                        next.accept(scratch, 0, produced);
-                        total += produced;
-                    }
-
-                    if (status == ModelStatus.COMPLETE)
-                    {
-                        done = true;
-                    }
-                    else
-                    {
-                        srcAt += consumed;
-                        flags = FLAGS_FIN;
-                    }
+                    srcAt += consumed;
+                    callFlags &= ~FLAGS_INIT;
                 }
             }
 
-            pipeline.reset();
+            outcome = result.set(finalStatus, inputLength, total);
         }
-        return total;
+        return outcome;
     }
 
     public int padding(
@@ -182,6 +299,8 @@ public final class KafkaCacheModel
         {
             pipeline.reset();
         }
+        started = false;
+        carried = 0;
     }
 
     public boolean identity()

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModel.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModel.java
@@ -79,7 +79,7 @@ public final class KafkaCacheModel
     }
 
     private final ModelPipeline pipeline;
-    private final MutableDirectBufferEx scratch;
+    private final MutableDirectBufferEx transformBuffer;
     private final ExpandableArrayBufferEx carry;
     private final Result result;
 
@@ -89,10 +89,10 @@ public final class KafkaCacheModel
     public static KafkaCacheModel decoder(
         ModelHandler handler,
         ModelTransform transform,
-        MutableDirectBufferEx scratch)
+        MutableDirectBufferEx transformBuffer)
     {
         return handler != null
-            ? new KafkaCacheModel(handler.supplyDecoder(ModelEnvelope.NONE, transform, ModelCache.NONE), scratch)
+            ? new KafkaCacheModel(handler.supplyDecoder(ModelEnvelope.NONE, transform, ModelCache.NONE), transformBuffer)
             : NONE;
     }
 
@@ -103,10 +103,10 @@ public final class KafkaCacheModel
         ModelHandler handler,
         ModelTransform transform,
         ModelEnvelope envelope,
-        MutableDirectBufferEx scratch)
+        MutableDirectBufferEx transformBuffer)
     {
         return handler != null
-            ? new KafkaCacheModel(handler.supplyDecoder(envelope, transform, ModelCache.WRITE), scratch)
+            ? new KafkaCacheModel(handler.supplyDecoder(envelope, transform, ModelCache.WRITE), transformBuffer)
             : NONE;
     }
 
@@ -117,10 +117,10 @@ public final class KafkaCacheModel
         ModelHandler handler,
         ModelTransform transform,
         ModelEnvelope envelope,
-        MutableDirectBufferEx scratch)
+        MutableDirectBufferEx transformBuffer)
     {
         return handler != null
-            ? new KafkaCacheModel(handler.supplyDecoder(envelope, transform, ModelCache.READ), scratch)
+            ? new KafkaCacheModel(handler.supplyDecoder(envelope, transform, ModelCache.READ), transformBuffer)
             : NONE;
     }
 
@@ -129,27 +129,27 @@ public final class KafkaCacheModel
     public static KafkaCacheModel encoder(
         ModelHandler handler,
         ModelEnvelope envelope,
-        MutableDirectBufferEx scratch)
+        MutableDirectBufferEx transformBuffer)
     {
         return handler != null
-            ? new KafkaCacheModel(handler.supplyEncoder(envelope, ModelTransform.NONE), scratch)
+            ? new KafkaCacheModel(handler.supplyEncoder(envelope, ModelTransform.NONE), transformBuffer)
             : NONE;
     }
 
     private KafkaCacheModel()
     {
         this.pipeline = null;
-        this.scratch = null;
+        this.transformBuffer = null;
         this.carry = new ExpandableArrayBufferEx();
         this.result = new Result();
     }
 
     KafkaCacheModel(
         ModelPipeline pipeline,
-        MutableDirectBufferEx scratch)
+        MutableDirectBufferEx transformBuffer)
     {
         this.pipeline = pipeline;
-        this.scratch = scratch;
+        this.transformBuffer = transformBuffer;
         this.carry = new ExpandableArrayBufferEx();
         this.result = new Result();
     }
@@ -230,14 +230,14 @@ public final class KafkaCacheModel
             while (finalStatus == null)
             {
                 final ModelPipelineResult step = pipeline.transform(traceId, bindingId, authorization, callFlags,
-                    src, srcAt, srcLimit, scratch, 0, scratch.capacity());
+                    src, srcAt, srcLimit, transformBuffer, 0, transformBuffer.capacity());
                 final ModelStatus status = step.status();
                 final int consumed = step.consumed();
                 final int produced = step.produced();
 
                 if (produced > 0)
                 {
-                    next.accept(scratch, 0, produced);
+                    next.accept(transformBuffer, 0, produced);
                     total += produced;
                 }
 

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModel.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModel.java
@@ -85,6 +85,7 @@ public final class KafkaCacheModel
 
     private boolean started;
     private int carried;
+    private boolean completedEarly;
 
     public static KafkaCacheModel decoder(
         ModelHandler handler,
@@ -227,6 +228,23 @@ public final class KafkaCacheModel
             int callFlags = (started ? 0 : FLAGS_INIT) | (flags & FLAGS_FIN);
             started = true;
             ModelStatus finalStatus = null;
+            if (completedEarly)
+            {
+                // a self-delimiting pipeline already finished on an earlier, non-FIN call (see the
+                // COMPLETE branch below) -- absorb this fragment without re-invoking the pipeline,
+                // since it has nothing left to produce, and only report COMPLETE once the caller's
+                // own FIN fragment actually arrives
+                if ((callFlags & FLAGS_FIN) != 0)
+                {
+                    completedEarly = false;
+                    started = false;
+                    finalStatus = ModelStatus.COMPLETE;
+                }
+                else
+                {
+                    finalStatus = ModelStatus.UNDERFLOW;
+                }
+            }
             while (finalStatus == null)
             {
                 final ModelPipelineResult step = pipeline.transform(traceId, bindingId, authorization, callFlags,
@@ -247,11 +265,21 @@ public final class KafkaCacheModel
                     started = false;
                     finalStatus = ModelStatus.REJECTED;
                 }
-                else if (status == ModelStatus.COMPLETE)
+                else if (status == ModelStatus.COMPLETE && (callFlags & FLAGS_FIN) != 0)
                 {
                     pipeline.reset();
                     started = false;
                     finalStatus = ModelStatus.COMPLETE;
+                }
+                else if (status == ModelStatus.COMPLETE)
+                {
+                    // a self-delimiting format (e.g. a JSON-view protobuf encode) can recognize its
+                    // own input is complete before the caller's own FIN fragment arrives -- remember
+                    // that and report UNDERFLOW so the caller keeps driving fragments; the eventual
+                    // FIN-flagged call is absorbed above without re-invoking the pipeline
+                    pipeline.reset();
+                    completedEarly = true;
+                    finalStatus = ModelStatus.UNDERFLOW;
                 }
                 else if (status == ModelStatus.UNDERFLOW && (callFlags & FLAGS_FIN) != 0)
                 {
@@ -301,6 +329,7 @@ public final class KafkaCacheModel
         }
         started = false;
         carried = 0;
+        completedEarly = false;
     }
 
     public boolean identity()

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
@@ -121,6 +121,7 @@ public final class KafkaCachePartition
 
     private final MutableDirectBufferEx entryInfo = new UnsafeBufferEx(new byte[FIELD_OFFSET_PADDED_KEY]);
     private final MutableDirectBufferEx valueInfo = new UnsafeBufferEx(new byte[Integer.BYTES]);
+    private final MutableInteger entryValueLimit = new MutableInteger(0);
 
     private final Varint32FW varintRO = new Varint32FW();
     private final KafkaCachePaddedKeyFW.Builder paddedKeyRW = new KafkaCachePaddedKeyFW.Builder()
@@ -301,6 +302,7 @@ public final class KafkaCachePartition
         long offset,
         KafkaKeyFW key,
         int valueLength,
+        int valuePaddingMax,
         int headersSizeMax)
     {
         Node head = sentinel.previous;
@@ -312,7 +314,7 @@ public final class KafkaCachePartition
         else
         {
             final int logRequired = entryInfo.capacity() + key.sizeof() + valueInfo.capacity() +
-                    Math.max(valueLength, 0) + headersSizeMax;
+                    Math.max(valueLength, 0) + SIZEOF_PADDING_LENGTH + valuePaddingMax + headersSizeMax;
             final int hashKeyRequired = key.length() != -1 ? 1 : 0;
             final int hashHeaderRequiredMax = headersSizeMax >> 2;
             final int hashRequiredMax = (hashKeyRequired + hashHeaderRequiredMax) * SIZEOF_INDEX_RECORD;
@@ -367,10 +369,17 @@ public final class KafkaCachePartition
         boolean verbose)
     {
         final int valueLength = value != null ? value.sizeof() : -1;
-        writeEntryStart(context, traceId, bindingId, authorization, offset, entryMark, valueMark, timestamp, timestampType,
-            producerId, key, valueLength, null, entryFlags, deltaType, value, transformKey, transformValue, keyEnvelope,
-            verbose);
-        writeEntryContinue(value);
+        final int valuePaddingMax = valueLength != -1 && transformValue != KafkaCacheModel.NONE
+            ? transformValue.padding(value.buffer(), value.offset(), valueLength)
+            : 0;
+        entryValueLimit.value = 0;
+        writeEntryStart(context, traceId, bindingId, authorization, offset, entryMark, valueMark, entryValueLimit, timestamp,
+            timestampType, producerId, key, valueLength, valuePaddingMax, null, entryFlags, deltaType, value, transformKey,
+            transformValue, keyEnvelope, verbose);
+        if (value != null)
+        {
+            writeEntryContinue(entryValueLimit, value);
+        }
         writeEntryFinish(headers, deltaType, context, traceId, bindingId, authorization, FLAGS_COMPLETE, offset, entryMark,
             valueMark, transformValue, valueEnvelope, trailersSizeMax, verbose);
     }
@@ -383,11 +392,13 @@ public final class KafkaCachePartition
         long offset,
         MutableInteger entryMark,
         MutableInteger valueMark,
+        MutableInteger valueLimit,
         long timestamp,
         KafkaTimestampType timestampType,
         long producerId,
         KafkaKeyFW key,
         int valueLength,
+        int valuePaddingMax,
         IntFunction<KafkaCacheEntryFW> findAncestor,
         int entryFlags,
         KafkaDeltaType deltaType,
@@ -422,8 +433,7 @@ public final class KafkaCachePartition
         int convertedPos = NO_CONVERTED_POSITION;
         if (valueLength != -1 && transformValue != KafkaCacheModel.NONE)
         {
-            int convertedPadding = transformValue.padding(payload.buffer(), payload.offset(), valueLength);
-            int convertedMaxLength = valueMaxLength + convertedPadding;
+            int convertedMaxLength = valueMaxLength + valuePaddingMax;
 
             convertedPos = convertedFile.capacity();
             convertedFile.advance(convertedPos + convertedMaxLength + SIZE_OF_INT * 2);
@@ -507,6 +517,11 @@ public final class KafkaCachePartition
         logFile.appendInt(valueLength);
 
         valueMark.value = logFile.capacity();
+        valueLimit.value = valueMark.value;
+
+        final int paddingLenAt = valueMark.value + valueMaxLength;
+        logFile.advance(paddingLenAt + SIZEOF_PADDING_LENGTH + valuePaddingMax);
+        logFile.writeInt(paddingLenAt, valuePaddingMax);
 
         final long keyHash = computeHash(logFile.readBytes(keyAt, keyRO::wrap));
 
@@ -514,7 +529,7 @@ public final class KafkaCachePartition
 
         final long ancestorOffset = ancestor != null ? ancestor.offset$() : NO_ANCESTOR_OFFSET;
         final int deltaPosition = deltaType == JSON_PATCH &&
-                                  ancestor != null && ancestor.valueLen() != -1 &&
+                                  ancestor != null && ancestor.paddedValue().length() != -1 &&
                                   valueLength != -1
                     ? deltaFile.capacity()
                     : NO_DELTA_POSITION;
@@ -541,6 +556,7 @@ public final class KafkaCachePartition
     }
 
     public void writeEntryContinue(
+        MutableInteger valueLimit,
         OctetsFW payload)
     {
         final Node head = sentinel.previous;
@@ -551,11 +567,7 @@ public final class KafkaCachePartition
 
         final KafkaCacheFile logFile = headSegment.logFile();
 
-        final int logAvailable = logFile.available();
-        final int logRequired = payload.sizeof();
-        assert logAvailable >= logRequired;
-
-        logFile.appendBytes(payload.buffer(), payload.offset(), payload.sizeof());
+        valueLimit.value += logFile.writeBytes(valueLimit.value, payload);
     }
 
     public void writeEntryFinish(
@@ -587,7 +599,9 @@ public final class KafkaCachePartition
         final KafkaCacheFile convertedFile = headSegment.convertedFile();
 
         final int valueLength = logFile.readInt(valueMark.value - SIZE_OF_INT);
-        assert logFile.capacity() - valueMark.value == Math.max(valueLength, 0);
+        final int paddingLenAt = valueMark.value + Math.max(valueLength, 0);
+        final int valuePaddingMax = logFile.readInt(paddingLenAt);
+        assert logFile.capacity() == paddingLenAt + SIZEOF_PADDING_LENGTH + valuePaddingMax;
 
         final int logAvailable = logFile.available();
         final int logRequired = headers.sizeof();
@@ -708,11 +722,11 @@ public final class KafkaCachePartition
         final KafkaCacheEntryFW headEntry = logFile.readBytes(logFile.markValue(), headEntryRO::wrap);
 
         if (deltaType == JSON_PATCH &&
-            ancestorEntry != null && ancestorEntry.valueLen() != -1 &&
-            headEntry.valueLen() != -1)
+            ancestorEntry != null && ancestorEntry.paddedValue().length() != -1 &&
+            headEntry.paddedValue().length() != -1)
         {
-            final OctetsFW ancestorValue = ancestorEntry.value();
-            final OctetsFW headValue = headEntry.value();
+            final OctetsFW ancestorValue = ancestorEntry.paddedValue().value();
+            final OctetsFW headValue = headEntry.paddedValue().value();
             assert headEntry.offset$() == progress;
 
             final JsonProvider json = JsonProvider.provider();
@@ -761,6 +775,7 @@ public final class KafkaCachePartition
         KafkaAckMode ackMode,
         KafkaKeyFW key,
         int valueLength,
+        int valuePaddingMax,
         ArrayFW<KafkaHeaderFW> headers,
         int trailersSizeMax,
         OctetsFW payload,
@@ -782,8 +797,7 @@ public final class KafkaCachePartition
         int convertedPos = NO_CONVERTED_POSITION;
         if (valueLength != -1 && transformValue != KafkaCacheModel.NONE)
         {
-            int convertedPadding = transformValue.padding(payload.buffer(), payload.offset(), valueLength);
-            int convertedMaxLength = valueMaxLength + convertedPadding;
+            int convertedMaxLength = valueMaxLength + valuePaddingMax;
 
             convertedPos = convertedFile.capacity();
             convertedFile.advance(convertedPos + convertedMaxLength + SIZE_OF_INT * 2);
@@ -856,10 +870,12 @@ public final class KafkaCachePartition
             valueMark.value = logFile.capacity();
             valueLimit.value = valueMark.value;
 
-            final int logAvailable = logFile.available() - valueMaxLength;
+            final int paddingLenAt = valueMark.value + valueMaxLength;
+            final int logAvailable = logFile.available() - valueMaxLength - SIZEOF_PADDING_LENGTH - valuePaddingMax;
             final int logRequired = headers.sizeof();
             assert logAvailable >= logRequired : String.format("%s %d >= %d", segment, logAvailable, logRequired);
-            logFile.advance(valueMark.value + valueMaxLength);
+            logFile.advance(paddingLenAt + SIZEOF_PADDING_LENGTH + valuePaddingMax);
+            logFile.writeInt(paddingLenAt, valuePaddingMax);
             logFile.appendBytes(headers);
 
             final int trailersAt = logFile.capacity();
@@ -950,6 +966,9 @@ public final class KafkaCachePartition
         assert segment != null;
 
         final KafkaCacheFile logFile = segment.logFile();
+
+        final int valuePaddingMax = logFile.readInt(valueLimit.value);
+        valueLimit.value += SIZEOF_PADDING_LENGTH + valuePaddingMax;
 
         final  Array32FW<KafkaHeaderFW> headers = logFile.readBytes(valueLimit.value, headersRO::wrap);
         valueLimit.value += headers.sizeof();

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
@@ -23,7 +23,6 @@ import static io.aklivity.zilla.runtime.binding.kafka.internal.types.KafkaDeltaT
 import static io.aklivity.zilla.runtime.binding.kafka.internal.types.cache.KafkaCacheEntryFW.FIELD_OFFSET_ACKNOWLEDGE;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.types.cache.KafkaCacheEntryFW.FIELD_OFFSET_ACK_MODE;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.types.cache.KafkaCacheEntryFW.FIELD_OFFSET_ANCESTOR;
-import static io.aklivity.zilla.runtime.binding.kafka.internal.types.cache.KafkaCacheEntryFW.FIELD_OFFSET_CONVERTED_POSITION;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.types.cache.KafkaCacheEntryFW.FIELD_OFFSET_DELTA_POSITION;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.types.cache.KafkaCacheEntryFW.FIELD_OFFSET_DESCENDANT;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.types.cache.KafkaCacheEntryFW.FIELD_OFFSET_FLAGS;
@@ -96,7 +95,6 @@ public final class KafkaCachePartition
     private static final long NO_DESCENDANT_OFFSET = -1L;
     private static final int NO_SEQUENCE = -1;
     private static final int NO_ACKNOWLEDGE = 0;
-    private static final int NO_CONVERTED_POSITION = -1;
     private static final int NO_DELTA_POSITION = -1;
 
     private static final String FORMAT_FETCH_PARTITION_DIRECTORY = "%s-%d";
@@ -438,11 +436,6 @@ public final class KafkaCachePartition
 
         logFile.mark();
 
-        // a value transform's output now streams directly into this entry's own paddedValue
-        // reservation below (see writeEntryContinue), so this entry never has convertedFile
-        // content -- convertedPosition stays NO_CONVERTED_POSITION regardless of transformValue
-        final int convertedPos = NO_CONVERTED_POSITION;
-
         entryMark.value = logFile.capacity();
 
         entryInfo.putLong(FIELD_OFFSET_OFFSET, progress);
@@ -453,7 +446,6 @@ public final class KafkaCachePartition
         entryInfo.putLong(FIELD_OFFSET_ANCESTOR, NO_ANCESTOR_OFFSET);
         entryInfo.putLong(FIELD_OFFSET_DESCENDANT, NO_DESCENDANT_OFFSET);
         entryInfo.putInt(FIELD_OFFSET_FLAGS, entryFlags);
-        entryInfo.putInt(FIELD_OFFSET_CONVERTED_POSITION, convertedPos);
         entryInfo.putInt(FIELD_OFFSET_DELTA_POSITION, NO_DELTA_POSITION);
         entryInfo.putShort(FIELD_OFFSET_ACK_MODE, KafkaAckMode.NONE.value());
 
@@ -829,11 +821,6 @@ public final class KafkaCachePartition
 
         final int valueMaxLength = valueLength == -1 ? 0 : valueLength;
 
-        // a value transform's output now streams directly into this entry's own paddedValue
-        // reservation below (see writeProduceEntryContinue), so this entry never has convertedFile
-        // content -- convertedPosition stays NO_CONVERTED_POSITION regardless of transformValue
-        final int convertedPos = NO_CONVERTED_POSITION;
-
         entryMark.value = logFile.capacity();
 
         entryInfo.putLong(FIELD_OFFSET_OFFSET, progress);
@@ -846,7 +833,6 @@ public final class KafkaCachePartition
         entryInfo.putLong(FIELD_OFFSET_ANCESTOR, NO_ANCESTOR_OFFSET);
         entryInfo.putLong(FIELD_OFFSET_DESCENDANT, NO_DESCENDANT_OFFSET);
         entryInfo.putInt(FIELD_OFFSET_FLAGS, 0x00);
-        entryInfo.putInt(FIELD_OFFSET_CONVERTED_POSITION, convertedPos);
         entryInfo.putInt(FIELD_OFFSET_DELTA_POSITION, NO_DELTA_POSITION);
         entryInfo.putShort(FIELD_OFFSET_ACK_MODE, ackMode.value());
 

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
@@ -80,6 +80,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.ExpandableDirectByteBuffer
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 
 public final class KafkaCachePartition
 {
@@ -122,6 +123,7 @@ public final class KafkaCachePartition
     private final MutableDirectBufferEx entryInfo = new UnsafeBufferEx(new byte[FIELD_OFFSET_PADDED_KEY]);
     private final MutableDirectBufferEx valueInfo = new UnsafeBufferEx(new byte[Integer.BYTES]);
     private final MutableInteger entryValueLimit = new MutableInteger(0);
+    private final MutableInteger entryHeadersMark = new MutableInteger(0);
 
     private final Varint32FW varintRO = new Varint32FW();
     private final KafkaCachePaddedKeyFW.Builder paddedKeyRW = new KafkaCachePaddedKeyFW.Builder()
@@ -372,16 +374,19 @@ public final class KafkaCachePartition
         final int valuePaddingMax = valueLength != -1 && transformValue != KafkaCacheModel.NONE
             ? transformValue.padding(value.buffer(), value.offset(), valueLength)
             : 0;
+        final int headersMax = headers.sizeof();
         entryValueLimit.value = 0;
-        writeEntryStart(context, traceId, bindingId, authorization, offset, entryMark, valueMark, entryValueLimit, timestamp,
-            timestampType, producerId, key, valueLength, valuePaddingMax, null, entryFlags, deltaType, value, transformKey,
-            transformValue, keyEnvelope, verbose);
+        writeEntryStart(context, traceId, bindingId, authorization, offset, entryMark, valueMark, entryValueLimit,
+            entryHeadersMark, timestamp, timestampType, producerId, key, valueLength, valuePaddingMax, headersMax,
+            trailersSizeMax, null, entryFlags, deltaType, value, transformKey, transformValue, keyEnvelope, valueEnvelope,
+            verbose);
         if (value != null)
         {
-            writeEntryContinue(entryValueLimit, value);
+            writeEntryContinue(traceId, bindingId, authorization, FLAGS_COMPLETE, entryMark, valueMark, entryValueLimit,
+                value, transformValue);
         }
-        writeEntryFinish(headers, deltaType, context, traceId, bindingId, authorization, FLAGS_COMPLETE, offset, entryMark,
-            valueMark, transformValue, valueEnvelope, trailersSizeMax, verbose);
+        writeEntryFinish(headers, deltaType, entryMark, valueMark, entryHeadersMark, headersMax, transformValue,
+            valueEnvelope, trailersSizeMax);
     }
 
     public void writeEntryStart(
@@ -393,12 +398,15 @@ public final class KafkaCachePartition
         MutableInteger entryMark,
         MutableInteger valueMark,
         MutableInteger valueLimit,
+        MutableInteger headersMark,
         long timestamp,
         KafkaTimestampType timestampType,
         long producerId,
         KafkaKeyFW key,
         int valueLength,
         int valuePaddingMax,
+        int headersMax,
+        int trailersSizeMax,
         IntFunction<KafkaCacheEntryFW> findAncestor,
         int entryFlags,
         KafkaDeltaType deltaType,
@@ -406,6 +414,7 @@ public final class KafkaCachePartition
         KafkaCacheModel transformKey,
         KafkaCacheModel transformValue,
         KafkaCacheKeyEnvelope keyEnvelope,
+        KafkaCacheTrailerEnvelope valueEnvelope,
         boolean verbose)
     {
         assert offset > this.progress : String.format("%d > %d", offset, this.progress);
@@ -424,23 +433,15 @@ public final class KafkaCachePartition
         final KafkaCacheFile hashFile = segment.hashFile();
         final KafkaCacheFile keysFile = segment.keysFile();
         final KafkaCacheFile nullsFile = segment.nullsFile();
-        final KafkaCacheFile convertedFile = segment.convertedFile();
 
         final int valueMaxLength = valueLength == -1 ? 0 : valueLength;
 
         logFile.mark();
 
-        int convertedPos = NO_CONVERTED_POSITION;
-        if (valueLength != -1 && transformValue != KafkaCacheModel.NONE)
-        {
-            int convertedMaxLength = valueMaxLength + valuePaddingMax;
-
-            convertedPos = convertedFile.capacity();
-            convertedFile.advance(convertedPos + convertedMaxLength + SIZE_OF_INT * 2);
-
-            convertedFile.writeInt(convertedPos, 0); // length
-            convertedFile.writeInt(convertedPos + SIZE_OF_INT, convertedMaxLength); // padding
-        }
+        // a value transform's output now streams directly into this entry's own paddedValue
+        // reservation below (see writeEntryContinue), so this entry never has convertedFile
+        // content -- convertedPosition stays NO_CONVERTED_POSITION regardless of transformValue
+        final int convertedPos = NO_CONVERTED_POSITION;
 
         entryMark.value = logFile.capacity();
 
@@ -523,6 +524,23 @@ public final class KafkaCachePartition
         logFile.advance(paddingLenAt + SIZEOF_PADDING_LENGTH + valuePaddingMax);
         logFile.writeInt(paddingLenAt, valuePaddingMax);
 
+        headersMark.value = logFile.capacity();
+        if (valueLength != -1 && transformValue != KafkaCacheModel.NONE)
+        {
+            // headers aren't known until writeEntryFinish, but a composed transform's envelope must
+            // already be claimed before the first writeEntryContinue call -- so this reserves headersMax
+            // (a worst-case bound) immediately followed by trailersSizeMax, and claims the trailersSizeMax
+            // portion as scratch for envelope.set() calls during the value drive. writeEntryFinish later
+            // writes the real (smaller) headers and trailers contiguously starting at headersMark, reusing
+            // these same bytes once the scratch content has been drained, and folds whatever is left over
+            // into the entry's own trailing paddingLen/padding fields
+            final int reservedMax = headersMax + trailersSizeMax + SIZEOF_PADDING_LENGTH;
+            logFile.advance(headersMark.value + reservedMax);
+
+            valueEnvelope.reset();
+            valueEnvelope.claim(logFile, headersMark.value + headersMax, trailersSizeMax);
+        }
+
         final long keyHash = computeHash(logFile.readBytes(keyAt, keyRO::wrap));
 
         final KafkaCacheEntryFW ancestor = findAncestor != null ? findAncestor.apply((int) keyHash) : null;
@@ -555,9 +573,16 @@ public final class KafkaCachePartition
         keysFile.appendLong(keyEntry);
     }
 
-    public void writeEntryContinue(
+    public int writeEntryContinue(
+        long traceId,
+        long bindingId,
+        long authorization,
+        int flags,
+        MutableInteger entryMark,
+        MutableInteger valueMark,
         MutableInteger valueLimit,
-        OctetsFW payload)
+        OctetsFW payload,
+        KafkaCacheModel transformValue)
     {
         final Node head = sentinel.previous;
         assert head != sentinel;
@@ -567,24 +592,72 @@ public final class KafkaCachePartition
 
         final KafkaCacheFile logFile = headSegment.logFile();
 
-        valueLimit.value += logFile.writeBytes(valueLimit.value, payload);
+        int transformed = 0;
+        if (payload != null)
+        {
+            if (transformValue == KafkaCacheModel.NONE)
+            {
+                valueLimit.value += logFile.writeBytes(valueLimit.value, payload);
+            }
+            else
+            {
+                // re-derives the reservation's total capacity from the placeholder length/paddingLen
+                // fields writeEntryStart already wrote -- both still hold their original, provisional
+                // values until the COMPLETE branch below finalizes them, so this is stable across every
+                // fragment of the same value
+                final int valueMaxLength = Math.max(logFile.readInt(valueMark.value - SIZE_OF_INT), 0);
+                final int paddingLenAt = valueMark.value + valueMaxLength;
+                final int valuePaddingMax = logFile.readInt(paddingLenAt);
+                final int reservedMax = valueMaxLength + valuePaddingMax;
+
+                final KafkaCacheModel.Output consumeTransformed = (buffer, index, length) ->
+                {
+                    final int written = valueLimit.value - valueMark.value;
+                    if (written + length > reservedMax)
+                    {
+                        logFile.writeInt(entryMark.value + FIELD_OFFSET_FLAGS, CACHE_ENTRY_FLAGS_ABORTED);
+                    }
+                    else
+                    {
+                        logFile.writeBytes(valueLimit.value, buffer, index, length);
+                        valueLimit.value += length;
+                    }
+                };
+
+                final KafkaCacheModel.Result result = transformValue.transform(traceId, bindingId, authorization, flags,
+                    payload.buffer(), payload.offset(), payload.limit(), consumeTransformed);
+
+                if (result.status() == ModelStatus.REJECTED)
+                {
+                    transformed = -1;
+                    logFile.writeInt(entryMark.value + FIELD_OFFSET_FLAGS, CACHE_ENTRY_FLAGS_ABORTED);
+                }
+                else if (result.status() == ModelStatus.COMPLETE)
+                {
+                    // the transformed value's real length rarely matches the reservation sized from the
+                    // raw value -- finalize length in place and relocate paddingLen to absorb whatever
+                    // slack remains, exactly as commitKeyOverride does for a transformed key
+                    final int actualLength = valueLimit.value - valueMark.value;
+                    final int finalPaddingLen = reservedMax - actualLength;
+                    logFile.writeInt(valueMark.value - SIZE_OF_INT, actualLength);
+                    logFile.writeInt(valueLimit.value, finalPaddingLen);
+                }
+            }
+        }
+
+        return transformed;
     }
 
     public void writeEntryFinish(
         ArrayFW<KafkaHeaderFW> headers,
         KafkaDeltaType deltaType,
-        EngineContext context,
-        long traceId,
-        long bindingId,
-        long authorization,
-        int flags,
-        long offset,
         MutableInteger entryMark,
         MutableInteger valueMark,
+        MutableInteger headersMark,
+        int headersMax,
         KafkaCacheModel transformValue,
         KafkaCacheTrailerEnvelope valueEnvelope,
-        int trailersSizeMax,
-        boolean verbose)
+        int trailersSizeMax)
     {
         final Node head = sentinel.previous;
         assert head != sentinel;
@@ -596,91 +669,54 @@ public final class KafkaCachePartition
         final KafkaCacheFile deltaFile = headSegment.deltaFile();
         final KafkaCacheFile hashFile = headSegment.hashFile();
         final KafkaCacheFile indexFile = headSegment.indexFile();
-        final KafkaCacheFile convertedFile = headSegment.convertedFile();
 
         final int valueLength = logFile.readInt(valueMark.value - SIZE_OF_INT);
         final int paddingLenAt = valueMark.value + Math.max(valueLength, 0);
         final int valuePaddingMax = logFile.readInt(paddingLenAt);
-        assert logFile.capacity() == paddingLenAt + SIZEOF_PADDING_LENGTH + valuePaddingMax;
-
-        final int logAvailable = logFile.available();
-        final int logRequired = headers.sizeof();
-        assert logAvailable >= logRequired : String.format("%s %d >= %d", headSegment, logAvailable, logRequired);
-
-        logFile.appendBytes(headers);
+        final int valueEnd = paddingLenAt + SIZEOF_PADDING_LENGTH + valuePaddingMax;
+        assert headersMark.value == valueEnd;
 
         Array32FW<KafkaHeaderFW> trailers = EMPTY_TRAILERS;
 
-        if (valueLength != -1 && transformValue != KafkaCacheModel.NONE &&
-            (logFile.readInt(entryMark.value + FIELD_OFFSET_FLAGS) & CACHE_ENTRY_FLAGS_ABORTED) == 0x00)
+        if (valueLength != -1 && transformValue != KafkaCacheModel.NONE)
         {
-            final KafkaCacheModel.Output consumeTransformed = (buffer, index, length) ->
-            {
-                final int convertedLengthAt = logFile.readInt(entryMark.value + FIELD_OFFSET_CONVERTED_POSITION);
-                final int convertedLength = convertedFile.readInt(convertedLengthAt);
-                final int convertedValueLimit = convertedLengthAt + SIZE_OF_INT + convertedLength;
-                final int convertedPadding = convertedFile.readInt(convertedValueLimit);
+            assert logFile.capacity() == headersMark.value + headersMax + trailersSizeMax + SIZEOF_PADDING_LENGTH;
 
-                if (convertedPadding < length)
+            final boolean aborted =
+                (logFile.readInt(entryMark.value + FIELD_OFFSET_FLAGS) & CACHE_ENTRY_FLAGS_ABORTED) != 0x00;
+
+            if (!aborted)
+            {
+                if (!valueEnvelope.isEmpty())
+                {
+                    valueEnvelope.writeHeaders(trailersRW.wrap(trailersRW.buffer(), 0, trailersRW.maxLimit()));
+                    trailers = trailersRW.build();
+                }
+
+                if (valueEnvelope.isOverflowed())
                 {
                     logFile.writeInt(entryMark.value + FIELD_OFFSET_FLAGS, CACHE_ENTRY_FLAGS_ABORTED);
-                    if (verbose)
-                    {
-                        System.out.printf("%s:%s %s: Skipping message on topic %s, partition %d, offset %d: " +
-                            "transformed value exceeded reserved capacity\n",
-                            System.currentTimeMillis(), context.supplyNamespace(bindingId),
-                            context.supplyLocalName(bindingId), topic, id, offset);
-                    }
-                }
-                else
-                {
-                    convertedFile.writeInt(convertedLengthAt, convertedLength + length);
-                    convertedFile.writeBytes(convertedValueLimit, buffer, index, length);
-                    convertedFile.writeInt(convertedValueLimit + length, convertedPadding - length);
-                }
-            };
-
-            // reserves the entry's own trailers + paddingLen + padding fields up front, sized to
-            // trailersSizeMax, and claims that same region as the scratch block a composed transform's
-            // envelope.set() calls write into during the value drive -- written directly rather than
-            // staged in a heap-resident arena, then folded back into the region's trailers/paddingLen
-            // once collection completes, so no separate append is needed afterwards. Mirrors the produce
-            // path's claim in writeProduceEntryStart (#2456), adapted to a single call since the populate
-            // path processes one entry at a time and can reserve, collect, and finalize within this method
-            final int trailersAt = logFile.capacity();
-            logFile.advance(trailersAt + trailersSizeMax + SIZEOF_PADDING_LENGTH);
-            logFile.writeBytes(trailersAt, EMPTY_TRAILERS);
-            logFile.writeInt(trailersAt + SIZEOF_EMPTY_TRAILERS, trailersSizeMax - SIZEOF_EMPTY_TRAILERS);
-
-            valueEnvelope.reset();
-            valueEnvelope.claim(logFile, trailersAt, trailersSizeMax);
-
-            int transformed = transformValue.transform(traceId, bindingId, authorization, logFile.buffer(),
-                valueMark.value, valueMark.value + valueLength, consumeTransformed);
-            if (transformed == -1)
-            {
-                logFile.writeInt(entryMark.value + FIELD_OFFSET_FLAGS, CACHE_ENTRY_FLAGS_ABORTED);
-                if (verbose)
-                {
-                    System.out.printf("%s:%s %s: Skipping invalid message on topic %s, partition %d, offset %d\n",
-                        System.currentTimeMillis(), context.supplyNamespace(bindingId),
-                        context.supplyLocalName(bindingId), topic, id, offset);
                 }
             }
-            else if (valueEnvelope.isOverflowed())
-            {
-                logFile.writeInt(entryMark.value + FIELD_OFFSET_FLAGS, CACHE_ENTRY_FLAGS_ABORTED);
-            }
-            else if (!valueEnvelope.isEmpty())
-            {
-                valueEnvelope.writeHeaders(trailersRW.wrap(trailersRW.buffer(), 0, trailersRW.maxLimit()));
-                trailers = trailersRW.build();
-                logFile.writeBytes(trailersAt, trailers);
-                logFile.writeInt(trailersAt + trailers.sizeof(), trailersSizeMax - trailers.sizeof());
-            }
+
+            // real headers and trailers are written contiguously starting at headersMark, reusing the
+            // bytes writeEntryStart reserved (and the composed transform's envelope used as scratch during
+            // the value drive) -- whatever is left over between their combined real size and the full
+            // worst-case reservation is folded into the entry's own trailing paddingLen/padding fields
+            logFile.writeBytes(headersMark.value, headers);
+            final int trailersAt = headersMark.value + headers.sizeof();
+            logFile.writeBytes(trailersAt, trailers);
+            final int entryPaddingLenAt = trailersAt + trailers.sizeof();
+            final int reservedEnd = headersMark.value + headersMax + trailersSizeMax + SIZEOF_PADDING_LENGTH;
+            logFile.writeInt(entryPaddingLenAt, reservedEnd - entryPaddingLenAt - SIZEOF_PADDING_LENGTH);
         }
         else
         {
+            final int logAvailable = logFile.available();
+            final int logRequired = headers.sizeof();
+            assert logAvailable >= logRequired : String.format("%s %d >= %d", headSegment, logAvailable, logRequired);
+
+            logFile.appendBytes(headers);
             logFile.appendBytes(EMPTY_TRAILERS);
             logFile.appendInt(0);
         }
@@ -790,21 +826,13 @@ public final class KafkaCachePartition
 
         final KafkaCacheFile indexFile = segment.indexFile();
         final KafkaCacheFile logFile = segment.logFile();
-        final KafkaCacheFile convertedFile = segment.convertedFile();
 
         final int valueMaxLength = valueLength == -1 ? 0 : valueLength;
 
-        int convertedPos = NO_CONVERTED_POSITION;
-        if (valueLength != -1 && transformValue != KafkaCacheModel.NONE)
-        {
-            int convertedMaxLength = valueMaxLength + valuePaddingMax;
-
-            convertedPos = convertedFile.capacity();
-            convertedFile.advance(convertedPos + convertedMaxLength + SIZE_OF_INT * 2);
-
-            convertedFile.writeInt(convertedPos, 0); // length
-            convertedFile.writeInt(convertedPos + SIZE_OF_INT, convertedMaxLength); // padding
-        }
+        // a value transform's output now streams directly into this entry's own paddedValue
+        // reservation below (see writeProduceEntryContinue), so this entry never has convertedFile
+        // content -- convertedPosition stays NO_CONVERTED_POSITION regardless of transformValue
+        final int convertedPos = NO_CONVERTED_POSITION;
 
         entryMark.value = logFile.capacity();
 
@@ -914,39 +942,56 @@ public final class KafkaCachePartition
         assert segment != null;
 
         final KafkaCacheFile logFile = segment.logFile();
-        final KafkaCacheFile convertedFile = segment.convertedFile();
 
         int transformed = 0;
         if (payload != null)
         {
-            valueLimit.value += logFile.writeBytes(valueLimit.value, payload);
-
-            if (transformValue != KafkaCacheModel.NONE)
+            if (transformValue == KafkaCacheModel.NONE)
             {
+                valueLimit.value += logFile.writeBytes(valueLimit.value, payload);
+            }
+            else
+            {
+                // re-derives the reservation's total capacity from the placeholder length/paddingLen
+                // fields writeProduceEntryStart already wrote -- both still hold their original,
+                // provisional values until the COMPLETE branch below finalizes them, so this is stable
+                // across every fragment of the same value
+                final int valueMaxLength = Math.max(logFile.readInt(valueMark.value - SIZE_OF_INT), 0);
+                final int paddingLenAt = valueMark.value + valueMaxLength;
+                final int valuePaddingMax = logFile.readInt(paddingLenAt);
+                final int reservedMax = valueMaxLength + valuePaddingMax;
+
                 final KafkaCacheModel.Output consumeTransformed = (buffer, index, length) ->
                 {
-                    final int convertedLengthAt = logFile.readInt(entryMark.value + FIELD_OFFSET_CONVERTED_POSITION);
-                    final int convertedLength = convertedFile.readInt(convertedLengthAt);
-                    final int convertedValueLimit = convertedLengthAt + SIZE_OF_INT + convertedLength;
-                    final int convertedPadding = convertedFile.readInt(convertedValueLimit);
-
-                    if (convertedPadding < length)
+                    final int written = valueLimit.value - valueMark.value;
+                    if (written + length > reservedMax)
                     {
                         logFile.writeInt(entryMark.value + FIELD_OFFSET_FLAGS, CACHE_ENTRY_FLAGS_ABORTED);
                     }
                     else
                     {
-                        convertedFile.writeInt(convertedLengthAt, convertedLength + length);
-                        convertedFile.writeBytes(convertedValueLimit, buffer, index, length);
-                        convertedFile.writeInt(convertedValueLimit + length, convertedPadding - length);
+                        logFile.writeBytes(valueLimit.value, buffer, index, length);
+                        valueLimit.value += length;
                     }
                 };
 
-                final int valueLength = valueLimit.value - valueMark.value;
-                if ((flags & FLAGS_FIN) != 0x00)
+                final KafkaCacheModel.Result result = transformValue.transform(traceId, bindingId, authorization, flags,
+                    payload.buffer(), payload.offset(), payload.limit(), consumeTransformed);
+
+                if (result.status() == ModelStatus.REJECTED)
                 {
-                    transformed = transformValue.transform(traceId, bindingId, authorization, logFile.buffer(),
-                        valueMark.value, valueMark.value + valueLength, consumeTransformed);
+                    transformed = -1;
+                    logFile.writeInt(entryMark.value + FIELD_OFFSET_FLAGS, CACHE_ENTRY_FLAGS_ABORTED);
+                }
+                else if (result.status() == ModelStatus.COMPLETE)
+                {
+                    // the transformed value's real length rarely matches the reservation sized from the
+                    // raw value -- finalize length in place and relocate paddingLen to absorb whatever
+                    // slack remains, exactly as commitKeyOverride does for a transformed key
+                    final int actualLength = valueLimit.value - valueMark.value;
+                    final int finalPaddingLen = reservedMax - actualLength;
+                    logFile.writeInt(valueMark.value - SIZE_OF_INT, actualLength);
+                    logFile.writeInt(valueLimit.value, finalPaddingLen);
                 }
             }
         }

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
@@ -422,7 +422,7 @@ public final class KafkaCachePartition
         int convertedPos = NO_CONVERTED_POSITION;
         if (valueLength != -1 && transformValue != KafkaCacheModel.NONE)
         {
-            int convertedPadding = transformValue.padding(payload.buffer(), payload.offset(), payload.sizeof());
+            int convertedPadding = transformValue.padding(payload.buffer(), payload.offset(), valueLength);
             int convertedMaxLength = valueMaxLength + convertedPadding;
 
             convertedPos = convertedFile.capacity();
@@ -782,7 +782,7 @@ public final class KafkaCachePartition
         int convertedPos = NO_CONVERTED_POSITION;
         if (valueLength != -1 && transformValue != KafkaCacheModel.NONE)
         {
-            int convertedPadding = transformValue.padding(payload.buffer(), payload.offset(), payload.sizeof());
+            int convertedPadding = transformValue.padding(payload.buffer(), payload.offset(), valueLength);
             int convertedMaxLength = valueMaxLength + convertedPadding;
 
             convertedPos = convertedFile.capacity();

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
@@ -381,7 +381,7 @@ public final class KafkaCachePartition
         if (value != null)
         {
             writeEntryContinue(traceId, bindingId, authorization, FLAGS_COMPLETE, entryMark, valueMark, entryValueLimit,
-                value, transformValue);
+                value, transformValue, valuePaddingMax);
         }
         writeEntryFinish(headers, deltaType, entryMark, valueMark, entryHeadersMark, headersMax, transformValue,
             valueEnvelope, trailersSizeMax);
@@ -574,7 +574,8 @@ public final class KafkaCachePartition
         MutableInteger valueMark,
         MutableInteger valueLimit,
         OctetsFW payload,
-        KafkaCacheModel transformValue)
+        KafkaCacheModel transformValue,
+        int valuePaddingMax)
     {
         final Node head = sentinel.previous;
         assert head != sentinel;
@@ -593,13 +594,14 @@ public final class KafkaCachePartition
             }
             else
             {
-                // re-derives the reservation's total capacity from the placeholder length/paddingLen
-                // fields writeEntryStart already wrote -- both still hold their original, provisional
-                // values until the COMPLETE branch below finalizes them, so this is stable across every
-                // fragment of the same value
+                // valueMaxLength re-derives the reservation's raw-value bound from the placeholder length
+                // field writeEntryStart already wrote -- that field sits before the value region so it is
+                // never touched by value writes until the COMPLETE branch below finalizes it, so this stays
+                // stable across every fragment of the same value. valuePaddingMax, in contrast, must come in
+                // as a parameter rather than being re-read from its on-disk marker: a growing transform's
+                // output can legitimately write past valueMaxLength bytes into that marker's position, so a
+                // later fragment in the same value would read back corrupted data
                 final int valueMaxLength = Math.max(logFile.readInt(valueMark.value - SIZE_OF_INT), 0);
-                final int paddingLenAt = valueMark.value + valueMaxLength;
-                final int valuePaddingMax = logFile.readInt(paddingLenAt);
                 final int reservedMax = valueMaxLength + valuePaddingMax;
 
                 final KafkaCacheModel.Output consumeTransformed = (buffer, index, length) ->
@@ -922,7 +924,8 @@ public final class KafkaCachePartition
         MutableInteger valueMark,
         MutableInteger valueLimit,
         OctetsFW payload,
-        KafkaCacheModel transformValue)
+        KafkaCacheModel transformValue,
+        int valuePaddingMax)
     {
         final KafkaCacheSegment segment = head.segment;
         assert segment != null;
@@ -938,13 +941,14 @@ public final class KafkaCachePartition
             }
             else
             {
-                // re-derives the reservation's total capacity from the placeholder length/paddingLen
-                // fields writeProduceEntryStart already wrote -- both still hold their original,
-                // provisional values until the COMPLETE branch below finalizes them, so this is stable
-                // across every fragment of the same value
+                // valueMaxLength re-derives the reservation's raw-value bound from the placeholder length
+                // field writeProduceEntryStart already wrote -- that field sits before the value region so
+                // it is never touched by value writes until the COMPLETE branch below finalizes it, so this
+                // stays stable across every fragment of the same value. valuePaddingMax, in contrast, must
+                // come in as a parameter rather than being re-read from its on-disk marker: a growing
+                // transform's output can legitimately write past valueMaxLength bytes into that marker's
+                // position, so a later fragment in the same value would read back corrupted data
                 final int valueMaxLength = Math.max(logFile.readInt(valueMark.value - SIZE_OF_INT), 0);
-                final int paddingLenAt = valueMark.value + valueMaxLength;
-                final int valuePaddingMax = logFile.readInt(paddingLenAt);
                 final int reservedMax = valueMaxLength + valuePaddingMax;
 
                 final KafkaCacheModel.Output consumeTransformed = (buffer, index, length) ->

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheSegment.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheSegment.java
@@ -37,7 +37,6 @@ public final class KafkaCacheSegment extends KafkaCacheObject<KafkaCacheSegment>
     private long timestamp;
 
     private final KafkaCacheFile logFile;
-    private final KafkaCacheFile convertedFile;
     private final KafkaCacheFile deltaFile;
     private final KafkaCacheIndexFile indexFile;
     private final KafkaCacheIndexFile hashFile;
@@ -84,7 +83,6 @@ public final class KafkaCacheSegment extends KafkaCacheObject<KafkaCacheSegment>
         this.lastOffset = OFFSET_LIVE;
         this.timestamp = currentTimeMillis();
         this.logFile = new KafkaCacheFile.Log(location, baseOffset, config.segmentBytes, appendBuf);
-        this.convertedFile = new KafkaCacheFile.Converted(location, baseOffset, config.segmentBytes, appendBuf);
         this.deltaFile = new KafkaCacheFile.Delta(location, baseOffset, config.segmentBytes, appendBuf);
         this.indexFile = new KafkaCacheFile.Index(location, baseOffset, config.segmentIndexBytes, appendBuf);
         this.hashFile = new KafkaCacheFile.HashScan(location, baseOffset, config.segmentIndexBytes, appendBuf, sortSpaceRef);
@@ -107,7 +105,6 @@ public final class KafkaCacheSegment extends KafkaCacheObject<KafkaCacheSegment>
         this.lastOffset = lastOffset;
         this.timestamp = timestamp;
         this.logFile = new KafkaCacheFile.Log(location, baseOffset);
-        this.convertedFile = new KafkaCacheFile.Converted(location, baseOffset);
         this.deltaFile = new KafkaCacheFile.Delta(location, baseOffset);
         this.indexFile = new KafkaCacheFile.Index(location, baseOffset);
         this.hashFile = new KafkaCacheFile.HashIndex(location, baseOffset);
@@ -174,11 +171,6 @@ public final class KafkaCacheSegment extends KafkaCacheObject<KafkaCacheSegment>
         return logFile;
     }
 
-    public KafkaCacheFile convertedFile()
-    {
-        return convertedFile;
-    }
-
     public KafkaCacheFile deltaFile()
     {
         return deltaFile;
@@ -207,7 +199,6 @@ public final class KafkaCacheSegment extends KafkaCacheObject<KafkaCacheSegment>
     public KafkaCacheSegment freeze()
     {
         logFile.freeze();
-        convertedFile.freeze();
         deltaFile.freeze();
         indexFile.freeze();
         hashFile.freeze();
@@ -230,7 +221,6 @@ public final class KafkaCacheSegment extends KafkaCacheObject<KafkaCacheSegment>
         indexFile.delete();
         hashFile.delete();
         nullsFile.delete();
-        convertedFile.delete();
         deltaFile.delete();
         keysFile.delete();
     }
@@ -287,7 +277,6 @@ public final class KafkaCacheSegment extends KafkaCacheObject<KafkaCacheSegment>
         indexFile.close();
         hashFile.close();
         nullsFile.close();
-        convertedFile.close();
         deltaFile.close();
         keysFile.close();
     }

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheTrailerEnvelope.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheTrailerEnvelope.java
@@ -27,7 +27,7 @@ import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 // A write-collecting ModelEnvelope for the producer-encode path: every set() call is appended, in
 // call order, directly into a block already claimed for this message in the partition's log file --
 // the same claim-per-message approach the log file already uses for a transformed value's own output
-// (see KafkaCachePartition's convertedFile handling), rather than staging entries in a heap-resident
+// (see KafkaCachePartition's paddedValue reservation), rather than staging entries in a heap-resident
 // arena first. Repeated names simply add further entries, so writeHeaders() below reproduces them as
 // that many repeated Kafka headers, in the same order they were set. claim() is called once per
 // message, right after its block is reserved; reset() clears tracking so one instance is reused

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientFetchFactory.java
@@ -1287,7 +1287,7 @@ public final class KafkaCacheClientFetchFactory implements BindingHandler
             final ArrayFW<KafkaHeaderFW> headers = nextEntry.headers();
             final ArrayFW<KafkaHeaderFW> trailers = nextEntry.trailers();
             final long ancestor = nextEntry.ancestor();
-            OctetsFW value = nextEntry.value();
+            OctetsFW value = nextEntry.paddedValue().value();
             if (!valueDecoder.identity() && value != null)
             {
                 if (messageOffset == 0)

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
@@ -717,11 +717,11 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                     break init;
                 }
 
-                final int valuePaddingMax = valueLength != -1 && stream.transformValue != KafkaCacheModel.NONE
+                stream.valuePaddingMax = valueLength != -1 && stream.transformValue != KafkaCacheModel.NONE
                     ? stream.transformValue.padding(valueFragment.buffer(), valueFragment.offset(), valueLength)
                     : 0;
 
-                stream.segment = partition.newHeadIfNecessary(partitionOffset, key, valueLength, valuePaddingMax,
+                stream.segment = partition.newHeadIfNecessary(partitionOffset, key, valueLength, stream.valuePaddingMax,
                     headersSizeMax);
 
                 if (stream.segment != null)
@@ -733,7 +733,7 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                     if (partition.writeProduceEntryStart(traceId, routedId, stream.authorization, partitionOffset,
                         stream.segment, stream.entryMark, stream.valueMark, stream.valueLimit, stream.trailersClaimMark,
                         timestamp, stream.initialId,
-                        producerId, producerEpoch, sequence, ackMode, key, valueLength, valuePaddingMax,
+                        producerId, producerEpoch, sequence, ackMode, key, valueLength, stream.valuePaddingMax,
                         headers, trailersSizeMax, valueFragment, stream.transformKey, stream.transformValue) == -1)
                     {
                         error = ERROR_INVALID_RECORD;
@@ -754,7 +754,7 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
             {
                 if (partition.writeProduceEntryContinue(traceId, routedId, stream.authorization, flags, stream.segment,
                         stream.entryMark, stream.valueMark, stream.valueLimit,
-                        valueFragment, stream.transformValue) == -1)
+                        valueFragment, stream.transformValue, stream.valuePaddingMax) == -1)
                 {
                     error = ERROR_INVALID_RECORD;
                 }
@@ -1281,6 +1281,7 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
         private KafkaCachePartition.Node segment;
 
         private int dataFlags = FLAGS_FIN;
+        private int valuePaddingMax;
 
         private int state;
 

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
@@ -1666,6 +1666,11 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
             long traceId,
             Flyweight extension)
         {
+            // a value already mid-transform (INIT seen, no FIN yet) is abandoned here -- reset so this
+            // stream's model instances never retain state from a torn-down value
+            transformKey.reset();
+            transformValue.reset();
+
             doClientInitialResetIfNecessary(traceId, extension);
             doClientReplyAbortIfNecessary(traceId);
         }

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
@@ -717,7 +717,12 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                     break init;
                 }
 
-                stream.segment = partition.newHeadIfNecessary(partitionOffset, key, valueLength, headersSizeMax);
+                final int valuePaddingMax = valueLength != -1 && stream.transformValue != KafkaCacheModel.NONE
+                    ? stream.transformValue.padding(valueFragment.buffer(), valueFragment.offset(), valueLength)
+                    : 0;
+
+                stream.segment = partition.newHeadIfNecessary(partitionOffset, key, valueLength, valuePaddingMax,
+                    headersSizeMax);
 
                 if (stream.segment != null)
                 {
@@ -728,7 +733,7 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                     if (partition.writeProduceEntryStart(traceId, routedId, stream.authorization, partitionOffset,
                         stream.segment, stream.entryMark, stream.valueMark, stream.valueLimit, stream.trailersClaimMark,
                         timestamp, stream.initialId,
-                        producerId, producerEpoch, sequence, ackMode, key, valueLength,
+                        producerId, producerEpoch, sequence, ackMode, key, valueLength, valuePaddingMax,
                         headers, trailersSizeMax, valueFragment, stream.transformKey, stream.transformValue) == -1)
                     {
                         error = ERROR_INVALID_RECORD;
@@ -812,7 +817,11 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
             final long traceId = flush.traceId();
             final int reserved = flush.reserved();
 
-            stream.segment = partition.newHeadIfNecessary(partitionOffset, EMPTY_KEY, 0, 0);
+            final int valuePaddingMax = stream.transformValue != KafkaCacheModel.NONE
+                ? stream.transformValue.padding(EMPTY_OCTETS.buffer(), EMPTY_OCTETS.offset(), 0)
+                : 0;
+
+            stream.segment = partition.newHeadIfNecessary(partitionOffset, EMPTY_KEY, 0, valuePaddingMax, 0);
 
             int error = NO_ERROR;
             if (stream.segment != null)
@@ -825,7 +834,8 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                     stream.entryMark, stream.valueMark, stream.valueLimit, stream.trailersClaimMark, now().toEpochMilli(),
                     stream.initialId,
                     PRODUCE_FLUSH_PRODUCER_ID, PRODUCE_FLUSH_PRODUCER_EPOCH, PRODUCE_FLUSH_SEQUENCE, KafkaAckMode.LEADER_ONLY,
-                    EMPTY_KEY, 0, EMPTY_TRAILERS, trailersSizeMax, EMPTY_OCTETS, stream.transformKey, stream.transformValue);
+                    EMPTY_KEY, 0, valuePaddingMax, EMPTY_TRAILERS, trailersSizeMax, EMPTY_OCTETS, stream.transformKey,
+                    stream.transformValue);
                 stream.partitionOffset = partitionOffset;
                 partitionOffset++;
 

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
@@ -1131,6 +1131,12 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
 
             state = KafkaState.closedReply(state);
 
+            // any value already mid-transform (INIT seen, no FIN yet) is abandoned here, whether or not
+            // a reconnect follows -- reset so a value fetched after reconnecting doesn't get its first
+            // fragment treated as a continuation of the abandoned one
+            transformKey.reset();
+            transformValue.reset();
+
             doServerFanoutInitialEndIfNecessary(traceId);
 
             if (reconnectDelay != 0 && !members.isEmpty())
@@ -1167,6 +1173,10 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             final long traceId = abort.traceId();
 
             state = KafkaState.closedReply(state);
+
+            // see onServerFanoutReplyEnd
+            transformKey.reset();
+            transformValue.reset();
 
             doServerFanoutInitialAbortIfNecessary(traceId);
 
@@ -1205,6 +1215,10 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             final OctetsFW extension = reset.extension();
 
             state = KafkaState.closedInitial(state);
+
+            // see onServerFanoutReplyEnd
+            transformKey.reset();
+            transformValue.reset();
 
             doServerFanoutReplyResetIfNecessary(traceId);
 

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
@@ -504,6 +504,8 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
         private final MutableInteger entryMark;
         private final MutableInteger valueMark;
         private final MutableInteger valueLimit;
+        private final MutableInteger headersMark;
+        private int headersMax;
 
         private long leaderId;
         private long initialId;
@@ -582,6 +584,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             this.entryMark = new MutableInteger(0);
             this.valueMark = new MutableInteger(0);
             this.valueLimit = new MutableInteger(0);
+            this.headersMark = new MutableInteger(0);
         }
 
         private void onServerFanoutMemberOpening(
@@ -924,13 +927,16 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                 final int deferred = kafkaFetchDataEx.deferred();
                 final int partitionId = kafkaFetchDataEx.partition().partitionId();
                 final long partitionOffset = kafkaFetchDataEx.partition().partitionOffset();
-                // reserves room for writeEntryFinish's trailers + paddingLen + padding fields, claimed up
-                // front as the scratch block a composed transform's envelope.set() calls write into (see
-                // KafkaCachePartition.writeEntryFinish) -- only when a value model is actually configured,
-                // matching writeEntryFinish's own transformValue != NONE guard, so a plain topic with no
-                // value model keeps its exact prior segment-capacity accounting
-                final int headersSizeMax =
-                    Math.max(kafkaFetchDataEx.headers().sizeof(), kafkaFetchDataEx.headersSizeMax()) +
+                // headersMax bounds the entry's real headers, unknown until writeEntryFinish. When a value
+                // model is configured, headersSizeMax additionally reserves room for writeEntryStart's
+                // combined headers/trailers/scratch claim (see KafkaCachePartition.writeEntryStart) --
+                // trailersSizeMax is reused for both the composed transform's envelope scratch during the
+                // value drive and the entry's own final trailers, so only one trailersSizeMax-sized share
+                // is required, not two. A plain topic with no value model keeps its exact prior
+                // segment-capacity accounting
+                final int headersMax = Math.max(kafkaFetchDataEx.headers().sizeof(), kafkaFetchDataEx.headersSizeMax());
+                this.headersMax = headersMax;
+                final int headersSizeMax = headersMax +
                     (transformValue != KafkaCacheModel.NONE ? trailersSizeMax + Integer.BYTES : 0);
                 final long timestamp = kafkaFetchDataEx.timestamp();
                 final KafkaTimestampType timestampType = kafkaFetchDataEx.timestampType().get();
@@ -984,13 +990,15 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                     ((flags & FLAGS_SKIP) != 0x00 ? CACHE_ENTRY_FLAGS_ABORTED : 0x00) |
                     (timestampType == AUTHORITATIVE ? CACHE_ENTRY_FLAGS_AUTHORITATIVE : 0x00);
                 partition.writeEntryStart(context, traceId, routedId, NO_AUTHORIZATION, partitionOffset, entryMark, valueMark,
-                    valueLimit, timestamp, timestampType, producerId, key, valueLength, valuePaddingMax, findAncestor,
-                    entryFlags, deltaType, valueFragment, transformKey, transformValue, transformKeyEnvelope, verbose);
+                    valueLimit, headersMark, timestamp, timestampType, producerId, key, valueLength, valuePaddingMax,
+                    headersMax, trailersSizeMax, findAncestor, entryFlags, deltaType, valueFragment, transformKey,
+                    transformValue, transformKeyEnvelope, transformValueEnvelope, verbose);
             }
 
             if (valueFragment != null)
             {
-                partition.writeEntryContinue(valueLimit, valueFragment);
+                partition.writeEntryContinue(traceId, routedId, NO_AUTHORIZATION, flags, entryMark, valueMark, valueLimit,
+                    valueFragment, transformValue);
             }
 
             if ((flags & FLAGS_FIN) != 0x00)
@@ -1009,8 +1017,8 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                 assert partitionId == partition.id();
                 assert partitionOffset >= this.partitionOffset;
 
-                partition.writeEntryFinish(headers, deltaType, context, traceId, routedId, NO_AUTHORIZATION, flags,
-                    partitionOffset, entryMark, valueMark, transformValue, transformValueEnvelope, trailersSizeMax, verbose);
+                partition.writeEntryFinish(headers, deltaType, entryMark, valueMark, headersMark, headersMax, transformValue,
+                    transformValueEnvelope, trailersSizeMax);
 
                 this.partitionOffset = partitionOffset;
                 this.stableOffset = stableOffset;

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
@@ -503,6 +503,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
         private final KafkaCacheTrailerEnvelope transformValueEnvelope;
         private final MutableInteger entryMark;
         private final MutableInteger valueMark;
+        private final MutableInteger valueLimit;
 
         private long leaderId;
         private long initialId;
@@ -580,6 +581,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                 KafkaCacheModel.writer(topicType.valueModel, valueTransform, ModelEnvelope.NONE, transformBuffer);
             this.entryMark = new MutableInteger(0);
             this.valueMark = new MutableInteger(0);
+            this.valueLimit = new MutableInteger(0);
         }
 
         private void onServerFanoutMemberOpening(
@@ -936,6 +938,9 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                 final KafkaKeyFW key = kafkaFetchDataEx.key();
                 final KafkaDeltaFW delta = kafkaFetchDataEx.delta();
                 final int valueLength = valueFragment != null ? valueFragment.sizeof() + deferred : -1;
+                final int valuePaddingMax = valueLength != -1 && transformValue != KafkaCacheModel.NONE
+                    ? transformValue.padding(valueFragment.buffer(), valueFragment.offset(), valueLength)
+                    : 0;
 
                 assert delta.type().get() == KafkaDeltaType.NONE;
                 assert delta.ancestorOffset() == -1L;
@@ -944,7 +949,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
 
                 final KafkaCachePartition.Node head = partition.head();
                 final KafkaCachePartition.Node nextHead =
-                        partition.newHeadIfNecessary(partitionOffset, key, valueLength, headersSizeMax);
+                        partition.newHeadIfNecessary(partitionOffset, key, valueLength, valuePaddingMax, headersSizeMax);
 
                 final long nextOffset = partition.nextOffset(defaultOffset);
                 assert partitionOffset >= 0 && partitionOffset >= nextOffset
@@ -979,13 +984,13 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                     ((flags & FLAGS_SKIP) != 0x00 ? CACHE_ENTRY_FLAGS_ABORTED : 0x00) |
                     (timestampType == AUTHORITATIVE ? CACHE_ENTRY_FLAGS_AUTHORITATIVE : 0x00);
                 partition.writeEntryStart(context, traceId, routedId, NO_AUTHORIZATION, partitionOffset, entryMark, valueMark,
-                    timestamp, timestampType, producerId, key, valueLength, findAncestor, entryFlags, deltaType, valueFragment,
-                    transformKey, transformValue, transformKeyEnvelope, verbose);
+                    valueLimit, timestamp, timestampType, producerId, key, valueLength, valuePaddingMax, findAncestor,
+                    entryFlags, deltaType, valueFragment, transformKey, transformValue, transformKeyEnvelope, verbose);
             }
 
             if (valueFragment != null)
             {
-                partition.writeEntryContinue(valueFragment);
+                partition.writeEntryContinue(valueLimit, valueFragment);
             }
 
             if ((flags & FLAGS_FIN) != 0x00)

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
@@ -506,6 +506,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
         private final MutableInteger valueLimit;
         private final MutableInteger headersMark;
         private int headersMax;
+        private int valuePaddingMax;
 
         private long leaderId;
         private long initialId;
@@ -944,7 +945,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                 final KafkaKeyFW key = kafkaFetchDataEx.key();
                 final KafkaDeltaFW delta = kafkaFetchDataEx.delta();
                 final int valueLength = valueFragment != null ? valueFragment.sizeof() + deferred : -1;
-                final int valuePaddingMax = valueLength != -1 && transformValue != KafkaCacheModel.NONE
+                this.valuePaddingMax = valueLength != -1 && transformValue != KafkaCacheModel.NONE
                     ? transformValue.padding(valueFragment.buffer(), valueFragment.offset(), valueLength)
                     : 0;
 
@@ -998,7 +999,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             if (valueFragment != null)
             {
                 partition.writeEntryContinue(traceId, routedId, NO_AUTHORIZATION, flags, entryMark, valueMark, valueLimit,
-                    valueFragment, transformValue);
+                    valueFragment, transformValue, valuePaddingMax);
             }
 
             if ((flags & FLAGS_FIN) != 0x00)

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerProduceFactory.java
@@ -1267,7 +1267,7 @@ public final class KafkaCacheServerProduceFactory implements BindingHandler
                     final KafkaKeyFW key = nextEntry.paddedKey().key();
                     final ArrayFW<KafkaHeaderFW> headers = nextEntry.headers();
                     final ArrayFW<KafkaHeaderFW> trailers = nextEntry.trailers();
-                    final OctetsFW value = nextEntry.value();
+                    final OctetsFW value = nextEntry.paddedValue().value();
                     final int remaining = value != null ? value.sizeof() - messageOffset : 0;
                     assert remaining >= 0;
                     final int initialPad = fan.initialPad;

--- a/runtime/binding-kafka/src/main/zilla/internal.idl
+++ b/runtime/binding-kafka/src/main/zilla/internal.idl
@@ -38,7 +38,6 @@ scope internal
             int64 ancestor;
             int64 descendant;
             int32 flags = 0;  // see KafkCacheEntryFlags
-            int32 convertedPosition = -1;
             int32 deltaPosition = -1;
             int16 ackMode = -1;
             internal::cache::KafkaCachePaddedKey paddedKey;

--- a/runtime/binding-kafka/src/main/zilla/internal.idl
+++ b/runtime/binding-kafka/src/main/zilla/internal.idl
@@ -42,8 +42,7 @@ scope internal
             int32 deltaPosition = -1;
             int16 ackMode = -1;
             internal::cache::KafkaCachePaddedKey paddedKey;
-            int32 valueLen;
-            octets[valueLen] value = null;
+            internal::cache::KafkaCachePaddedValue paddedValue;
             kafka::KafkaHeader[] headers;
             kafka::KafkaHeader[] trailers;
             uint32 paddingLen;

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModelTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModelTest.java
@@ -294,6 +294,32 @@ public class KafkaCacheModelTest
         assertEquals(1, pipeline.resetCount);
     }
 
+    // regression coverage for zilla#2461: a self-delimiting format (e.g. a JSON-view protobuf
+    // encode) can recognize its own input is complete from content alone, before the caller's own
+    // FIN fragment arrives -- the real HTTP-to-Kafka produce mapping still always follows with a
+    // trailing FIN-flagged fragment carrying no further bytes, which must be absorbed as this
+    // value's true completion rather than treated as the start of a new, invalid empty value
+    @Test
+    public void shouldAbsorbTrailingEmptyFinAfterEarlyCompletion()
+    {
+        SelfDelimitingPipeline pipeline = new SelfDelimitingPipeline();
+        KafkaCacheModel model = new KafkaCacheModel(pipeline, new UnsafeBufferEx(new byte[256]));
+
+        KafkaCacheModel.Result first = model.transform(0L, 0L, 0L, FLAGS_INIT, value(""), 0, 0, sink);
+        assertEquals(ModelStatus.UNDERFLOW, first.status());
+
+        KafkaCacheModel.Result second = model.transform(0L, 0L, 0L, 0x00, value("hello"), 0, 5, sink);
+        assertEquals(ModelStatus.UNDERFLOW, second.status());
+        assertOutput("hello");
+
+        KafkaCacheModel.Result third = model.transform(0L, 0L, 0L, FLAGS_FIN, value(""), 0, 0, sink);
+        assertEquals(ModelStatus.COMPLETE, third.status());
+        assertEquals(0, third.produced());
+
+        assertEquals(2, pipeline.transformCount);
+        assertEquals(1, pipeline.resetCount);
+    }
+
     private static TestModelHandler handler(
         int length)
     {
@@ -488,6 +514,48 @@ public class KafkaCacheModelTest
             dst.putBytes(dstIndex, src, srcIndex, consumed);
             final ModelStatus status = fin ? ModelStatus.COMPLETE : ModelStatus.UNDERFLOW;
             return result.set(status, consumed, consumed);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+
+        @Override
+        public void reset()
+        {
+            resetCount++;
+        }
+    }
+
+    // a pipeline that completes as soon as it sees a non-empty fragment, independent of the
+    // caller's own FIN bit -- stands in for a self-delimiting format (e.g. JSON) whose own content
+    // tells it the value is done
+    private static final class SelfDelimitingPipeline implements ModelPipeline
+    {
+        private final ModelPipelineResult result = new ModelPipelineResult();
+        private int resetCount;
+        private int transformCount;
+
+        @Override
+        public ModelPipelineResult transform(
+            long traceId,
+            long bindingId,
+            long authorization,
+            int flags,
+            DirectBufferEx src,
+            int srcIndex,
+            int srcLimit,
+            MutableDirectBufferEx dst,
+            int dstIndex,
+            int dstLimit)
+        {
+            transformCount++;
+            final int length = srcLimit - srcIndex;
+            dst.putBytes(dstIndex, src, srcIndex, length);
+            final ModelStatus status = length > 0 ? ModelStatus.COMPLETE : ModelStatus.UNDERFLOW;
+            return result.set(status, length, length);
         }
 
         @Override

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModelTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModelTest.java
@@ -21,6 +21,9 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.agrona.collections.MutableInteger;
 import org.junit.Test;
 
@@ -40,6 +43,9 @@ import io.aklivity.zilla.runtime.engine.test.internal.model.TestModelHandler;
 
 public class KafkaCacheModelTest
 {
+    private static final int FLAGS_INIT = 0x02;
+    private static final int FLAGS_FIN = 0x01;
+
     private final MutableDirectBufferEx value = new UnsafeBufferEx(new byte[256]);
     private final MutableDirectBufferEx output = new UnsafeBufferEx(new byte[256]);
     private final MutableInteger outputLength = new MutableInteger();
@@ -208,6 +214,86 @@ public class KafkaCacheModelTest
         assertOutput("world");
     }
 
+    @Test
+    public void shouldTransformAcrossMultipleFragments()
+    {
+        PassthroughFragmentPipeline pipeline = new PassthroughFragmentPipeline();
+        KafkaCacheModel model = new KafkaCacheModel(pipeline, new UnsafeBufferEx(new byte[256]));
+
+        KafkaCacheModel.Result first = model.transform(0L, 0L, 0L, FLAGS_INIT, value("hel"), 0, 3, sink);
+        assertEquals(ModelStatus.UNDERFLOW, first.status());
+        assertEquals(3, first.consumed());
+        assertEquals(3, first.produced());
+
+        KafkaCacheModel.Result second = model.transform(0L, 0L, 0L, FLAGS_FIN, value("lo"), 0, 2, sink);
+        assertEquals(ModelStatus.COMPLETE, second.status());
+        assertEquals(2, second.consumed());
+        assertEquals(2, second.produced());
+
+        assertOutput("hello");
+        assertEquals(1, pipeline.resetCount);
+        assertEquals(1, (int) pipeline.flagsSeen.stream().filter(f -> (f & FLAGS_INIT) != 0).count());
+    }
+
+    @Test
+    public void shouldDrainOverflowWithinOneFragment()
+    {
+        KafkaCacheModel model = KafkaCacheModel.decoder(handler(5), ModelTransform.NONE, new UnsafeBufferEx(new byte[2]));
+
+        KafkaCacheModel.Result result = model.transform(0L, 0L, 0L, FLAGS_INIT | FLAGS_FIN, value("hello"), 0, 5, sink);
+
+        assertEquals(ModelStatus.COMPLETE, result.status());
+        assertEquals(5, result.produced());
+        assertOutput("hello");
+    }
+
+    @Test
+    public void shouldRejectThenRecoverOnSameInstance()
+    {
+        KafkaCacheModel model = KafkaCacheModel.decoder(handler(5), ModelTransform.NONE, new UnsafeBufferEx(new byte[256]));
+
+        KafkaCacheModel.Result rejected = model.transform(0L, 0L, 0L, FLAGS_INIT | FLAGS_FIN, value("nope"), 0, 4, sink);
+        assertEquals(ModelStatus.REJECTED, rejected.status());
+
+        outputLength.value = 0;
+        KafkaCacheModel.Result recovered = model.transform(0L, 0L, 0L, FLAGS_INIT | FLAGS_FIN, value("world"), 0, 5, sink);
+
+        assertEquals(ModelStatus.COMPLETE, recovered.status());
+        assertEquals(5, recovered.produced());
+        assertOutput("world");
+    }
+
+    @Test
+    public void shouldRejectWhenPipelineUnderflowsAtFin()
+    {
+        AlwaysUnderflowPipeline pipeline = new AlwaysUnderflowPipeline();
+        KafkaCacheModel model = new KafkaCacheModel(pipeline, new UnsafeBufferEx(new byte[256]));
+
+        KafkaCacheModel.Result result = model.transform(0L, 0L, 0L, FLAGS_INIT | FLAGS_FIN, value("hello"), 0, 5, sink);
+
+        assertEquals(ModelStatus.REJECTED, result.status());
+        assertEquals(1, pipeline.resetCount);
+    }
+
+    @Test
+    public void shouldRetainAndPrependUnconsumedTailAcrossFragments()
+    {
+        UnderConsumingPipeline pipeline = new UnderConsumingPipeline();
+        KafkaCacheModel model = new KafkaCacheModel(pipeline, new UnsafeBufferEx(new byte[256]));
+
+        KafkaCacheModel.Result first = model.transform(0L, 0L, 0L, FLAGS_INIT, value("abc"), 0, 3, sink);
+        assertEquals(ModelStatus.UNDERFLOW, first.status());
+
+        KafkaCacheModel.Result second = model.transform(0L, 0L, 0L, 0x00, value("d"), 0, 1, sink);
+        assertEquals(ModelStatus.UNDERFLOW, second.status());
+
+        KafkaCacheModel.Result third = model.transform(0L, 0L, 0L, FLAGS_FIN, value("e"), 0, 1, sink);
+        assertEquals(ModelStatus.COMPLETE, third.status());
+
+        assertOutput("abcde");
+        assertEquals(1, pipeline.resetCount);
+    }
+
     private static TestModelHandler handler(
         int length)
     {
@@ -288,6 +374,132 @@ public class KafkaCacheModelTest
         {
             this.encoderEnvelope = envelope;
             return null;
+        }
+    }
+
+    // an identity pipeline that echoes exactly what it is given each call and completes only under FIN --
+    // stands in for a real pipeline's fragment-boundary contract without any parsing of its own, so tests
+    // can isolate KafkaCacheModel's own INIT-once / reset-once-per-value mechanics
+    private static final class PassthroughFragmentPipeline implements ModelPipeline
+    {
+        private static final int FLAGS_FIN = 0x01;
+
+        private final ModelPipelineResult result = new ModelPipelineResult();
+        private final List<Integer> flagsSeen = new ArrayList<>();
+        private int resetCount;
+
+        @Override
+        public ModelPipelineResult transform(
+            long traceId,
+            long bindingId,
+            long authorization,
+            int flags,
+            DirectBufferEx src,
+            int srcIndex,
+            int srcLimit,
+            MutableDirectBufferEx dst,
+            int dstIndex,
+            int dstLimit)
+        {
+            flagsSeen.add(flags);
+            final int length = srcLimit - srcIndex;
+            dst.putBytes(dstIndex, src, srcIndex, length);
+            final ModelStatus status = (flags & FLAGS_FIN) != 0 ? ModelStatus.COMPLETE : ModelStatus.UNDERFLOW;
+            return result.set(status, length, length);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+
+        @Override
+        public void reset()
+        {
+            resetCount++;
+        }
+    }
+
+    // a pipeline that never resolves, even when handed FLAGS_FIN, standing in for a non-compliant
+    // pipeline so a test can prove KafkaCacheModel's own defensive REJECTED fallback
+    private static final class AlwaysUnderflowPipeline implements ModelPipeline
+    {
+        private final ModelPipelineResult result = new ModelPipelineResult();
+        private int resetCount;
+
+        @Override
+        public ModelPipelineResult transform(
+            long traceId,
+            long bindingId,
+            long authorization,
+            int flags,
+            DirectBufferEx src,
+            int srcIndex,
+            int srcLimit,
+            MutableDirectBufferEx dst,
+            int dstIndex,
+            int dstLimit)
+        {
+            final int length = srcLimit - srcIndex;
+            dst.putBytes(dstIndex, src, srcIndex, length);
+            return result.set(ModelStatus.UNDERFLOW, length, length);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+
+        @Override
+        public void reset()
+        {
+            resetCount++;
+        }
+    }
+
+    // a pipeline that only ever echoes a single byte per call, forcing KafkaCacheModel to carry the rest
+    // of each fragment forward and prepend it to the next one; resolves only once every real byte of the
+    // value has finally arrived under FLAGS_FIN, since there is no more input left to wait for by then
+    private static final class UnderConsumingPipeline implements ModelPipeline
+    {
+        private static final int FLAGS_FIN = 0x01;
+
+        private final ModelPipelineResult result = new ModelPipelineResult();
+        private int resetCount;
+
+        @Override
+        public ModelPipelineResult transform(
+            long traceId,
+            long bindingId,
+            long authorization,
+            int flags,
+            DirectBufferEx src,
+            int srcIndex,
+            int srcLimit,
+            MutableDirectBufferEx dst,
+            int dstIndex,
+            int dstLimit)
+        {
+            final boolean fin = (flags & FLAGS_FIN) != 0;
+            final int available = srcLimit - srcIndex;
+            final int consumed = fin ? available : Math.min(1, available);
+            dst.putBytes(dstIndex, src, srcIndex, consumed);
+            final ModelStatus status = fin ? ModelStatus.COMPLETE : ModelStatus.UNDERFLOW;
+            return result.set(status, consumed, consumed);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+
+        @Override
+        public void reset()
+        {
+            resetCount++;
         }
     }
 

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
@@ -67,7 +67,7 @@ public class KafkaCachePartitionTest
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
-    private final MutableDirectBufferEx scratch = new UnsafeBufferEx(new byte[8192]);
+    private final MutableDirectBufferEx transformBuffer = new UnsafeBufferEx(new byte[8192]);
     private final KafkaCacheEntryFW entryRO = new KafkaCacheEntryFW();
     private final KafkaCachePaddedValueFW paddedValueRO = new KafkaCachePaddedValueFW();
 
@@ -290,7 +290,7 @@ public class KafkaCachePartitionTest
         OctetsFW value = value(buffer, headers.limit(), "hello");
 
         UppercasingPipeline pipeline = new UppercasingPipeline();
-        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, transformBuffer);
 
         int transformed = partition.writeProduceEntryStart(1L, 1L, 0L, 11L, head, entryMark, valueMark, valueLimit,
             trailersClaimMark, 0L, 1L, -1L, (short) 0, 0, KafkaAckMode.NONE, key, 5, 4, headers, 256,
@@ -329,7 +329,7 @@ public class KafkaCachePartitionTest
         OctetsFW secondFragment = value(buffer, headers.limit() + 3, "lo");
 
         UppercasingPipeline pipeline = new UppercasingPipeline();
-        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, transformBuffer);
 
         int transformed = partition.writeProduceEntryStart(1L, 1L, 0L, 11L, head, entryMark, valueMark, valueLimit,
             trailersClaimMark, 0L, 1L, -1L, (short) 0, 0, KafkaAckMode.NONE, key, 5, 4, headers, 256,
@@ -364,7 +364,7 @@ public class KafkaCachePartitionTest
         OctetsFW value = value(buffer, headers.limit(), "hello");
 
         UppercasingPipeline pipeline = new UppercasingPipeline();
-        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, transformBuffer);
 
         partition.writeProduceEntryStart(1L, 1L, 0L, 11L, head, entryMark, valueMark, valueLimit,
             trailersClaimMark, 0L, 1L, -1L, (short) 0, 0, KafkaAckMode.NONE, key, 5, 0, headers, 256,
@@ -395,7 +395,7 @@ public class KafkaCachePartitionTest
         OctetsFW payload = value(buffer, headers.limit(), "hello");
 
         DoublingPipeline pipeline = new DoublingPipeline();
-        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, transformBuffer);
 
         final int valuePaddingMax = 8;
         partition.writeProduceEntryStart(1L, 1L, 0L, 11L, head, entryMark, valueMark, valueLimit,
@@ -446,7 +446,7 @@ public class KafkaCachePartitionTest
         OctetsFW payload = value(buffer, headers.limit(), "hello");
 
         DoublingPipeline pipeline = new DoublingPipeline();
-        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, transformBuffer);
         KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
 
         final int valuePaddingMax = 8;
@@ -614,7 +614,7 @@ public class KafkaCachePartitionTest
         OctetsFW value = value(buffer, headers.limit(), "hello");
 
         KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
-        KafkaCacheModel transformValue = KafkaCacheModel.writer(handler(5), ModelTransform.NONE, valueEnvelope, scratch);
+        KafkaCacheModel transformValue = KafkaCacheModel.writer(handler(5), ModelTransform.NONE, valueEnvelope, transformBuffer);
 
         partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
             key, headers, value, 0x00, KafkaDeltaType.NONE, KafkaCacheModel.NONE, transformValue,
@@ -641,7 +641,7 @@ public class KafkaCachePartitionTest
         OctetsFW value = value(buffer, headers.limit(), "hello");
 
         UppercasingPipeline pipeline = new UppercasingPipeline();
-        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, transformBuffer);
         KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
 
         partition.writeEntryStart(null, 1L, 1L, 0L, 11L, entryMark, valueMark, valueLimit, headersMark, 0L,
@@ -680,7 +680,7 @@ public class KafkaCachePartitionTest
         OctetsFW secondFragment = value(buffer, headers.limit() + 3, "lo");
 
         UppercasingPipeline pipeline = new UppercasingPipeline();
-        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, transformBuffer);
         KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
 
         partition.writeEntryStart(null, 1L, 1L, 0L, 11L, entryMark, valueMark, valueLimit, headersMark, 0L,
@@ -716,7 +716,7 @@ public class KafkaCachePartitionTest
         OctetsFW value = value(buffer, headers.limit(), "hello");
 
         UppercasingPipeline pipeline = new UppercasingPipeline();
-        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, transformBuffer);
         KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
 
         partition.writeEntryStart(null, 1L, 1L, 0L, 11L, entryMark, valueMark, valueLimit, headersMark, 0L,
@@ -754,7 +754,8 @@ public class KafkaCachePartitionTest
         int valueLength = 5;
 
         KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
-        KafkaCacheModel transformValue = KafkaCacheModel.writer(paddingHandler(), ModelTransform.NONE, valueEnvelope, scratch);
+        KafkaCacheModel transformValue =
+            KafkaCacheModel.writer(paddingHandler(), ModelTransform.NONE, valueEnvelope, transformBuffer);
 
         int valuePaddingMax = transformValue.padding(firstFragment.buffer(), firstFragment.offset(), valueLength);
 
@@ -781,7 +782,7 @@ public class KafkaCachePartitionTest
         OctetsFW value = value(buffer, headers.limit(), "hello");
 
         KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
-        KafkaCacheModel transformValue = KafkaCacheModel.writer(handler(99), ModelTransform.NONE, valueEnvelope, scratch);
+        KafkaCacheModel transformValue = KafkaCacheModel.writer(handler(99), ModelTransform.NONE, valueEnvelope, transformBuffer);
 
         partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
             key, headers, value, 0x00, KafkaDeltaType.NONE, KafkaCacheModel.NONE, transformValue,
@@ -810,9 +811,9 @@ public class KafkaCachePartitionTest
         ModelTransform keyTransform = new KafkaExtractTransform("$.key", KafkaCacheKeyEnvelope.NAME, keyEnvelope);
         ModelTransform valueTransform = new KafkaExtractTransform("$.region", "region", valueEnvelope);
         KafkaCacheModel transformKey =
-            KafkaCacheModel.writer(extractingHandler("$.key"), keyTransform, keyEnvelope, scratch);
+            KafkaCacheModel.writer(extractingHandler("$.key"), keyTransform, keyEnvelope, transformBuffer);
         KafkaCacheModel transformValue =
-            KafkaCacheModel.writer(extractingHandler("$.region"), valueTransform, valueEnvelope, scratch);
+            KafkaCacheModel.writer(extractingHandler("$.region"), valueTransform, valueEnvelope, transformBuffer);
 
         partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
             key, headers, value, 0x00, KafkaDeltaType.NONE, transformKey, transformValue, keyEnvelope, valueEnvelope,
@@ -845,7 +846,7 @@ public class KafkaCachePartitionTest
         KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
         ModelTransform valueTransform = new KafkaExtractTransform("$.region", "region", valueEnvelope);
         KafkaCacheModel transformValue =
-            KafkaCacheModel.writer(extractingHandler("$.region"), valueTransform, valueEnvelope, scratch);
+            KafkaCacheModel.writer(extractingHandler("$.region"), valueTransform, valueEnvelope, transformBuffer);
 
         KafkaKeyFW key1 = key(buffer, "k1");
         Array32FW<KafkaHeaderFW> headers1 = noHeaders(buffer, key1.limit());
@@ -884,7 +885,8 @@ public class KafkaCachePartitionTest
         KafkaCacheKeyEnvelope keyEnvelope = new KafkaCacheKeyEnvelope();
         ModelTransform keyTransform = new KafkaExtractTransform("$.id", KafkaCacheKeyEnvelope.NAME, keyEnvelope);
         KafkaCacheModel transformKey = KafkaCacheModel.writer(
-            fieldsHandler("$.id", "this-override-is-much-longer-than-the-original-key"), keyTransform, keyEnvelope, scratch);
+            fieldsHandler("$.id", "this-override-is-much-longer-than-the-original-key"), keyTransform, keyEnvelope,
+            transformBuffer);
 
         partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
             key, headers, value, 0x00, KafkaDeltaType.NONE, transformKey, KafkaCacheModel.NONE, keyEnvelope,
@@ -911,7 +913,7 @@ public class KafkaCachePartitionTest
         KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
         ModelTransform valueTransform = new KafkaExtractTransform("$.region", "region", valueEnvelope);
         KafkaCacheModel transformValue =
-            KafkaCacheModel.writer(extractingHandler("$.region"), valueTransform, valueEnvelope, scratch);
+            KafkaCacheModel.writer(extractingHandler("$.region"), valueTransform, valueEnvelope, transformBuffer);
 
         partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
             key, headers, value, 0x00, KafkaDeltaType.NONE, KafkaCacheModel.NONE, transformValue,
@@ -945,7 +947,7 @@ public class KafkaCachePartitionTest
         KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
         ModelTransform valueTransform = new KafkaExtractTransform("$.region", "region", valueEnvelope);
         KafkaCacheModel transformValue =
-            KafkaCacheModel.writer(extractingHandler("$.region"), valueTransform, valueEnvelope, scratch);
+            KafkaCacheModel.writer(extractingHandler("$.region"), valueTransform, valueEnvelope, transformBuffer);
 
         KafkaKeyFW nullKey = new OctetsFW().wrap(new UnsafeBufferEx(new byte[] { 0x00 }), 0, 1)
             .get(new KafkaKeyFW()::wrap);
@@ -990,7 +992,7 @@ public class KafkaCachePartitionTest
         // the key's model surfaces the extracted field between two others, so the entry key is only right
         // if the fields the traversal merely surfaces stay out of the key lane
         KafkaCacheModel transformKey = KafkaCacheModel.writer(
-            fieldsHandler("$.tenant", "tenantA", "$.id", "id42", "$.zone", "euw1"), keyTransform, keyEnvelope, scratch);
+            fieldsHandler("$.tenant", "tenantA", "$.id", "id42", "$.zone", "euw1"), keyTransform, keyEnvelope, transformBuffer);
 
         partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
             key, headers, value, 0x00, KafkaDeltaType.NONE, transformKey, KafkaCacheModel.NONE, keyEnvelope,
@@ -1013,9 +1015,9 @@ public class KafkaCachePartitionTest
         KafkaCacheTrailerEnvelope envelopeA = new KafkaCacheTrailerEnvelope();
         KafkaCacheTrailerEnvelope envelopeB = new KafkaCacheTrailerEnvelope();
         KafkaCacheModel transformValueA = KafkaCacheModel.writer(extractingHandler("$.region"),
-            new KafkaExtractTransform("$.region", "region", envelopeA), envelopeA, scratch);
+            new KafkaExtractTransform("$.region", "region", envelopeA), envelopeA, transformBuffer);
         KafkaCacheModel transformValueB = KafkaCacheModel.writer(extractingHandler("$.region"),
-            new KafkaExtractTransform("$.region", "region", envelopeB), envelopeB, scratch);
+            new KafkaExtractTransform("$.region", "region", envelopeB), envelopeB, transformBuffer);
 
         assertEquals("AAA", writeAndReadTrailer(partition, head, entryMark, valueMark, buffer, 11L, "AAA",
             transformValueA, envelopeA));

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
@@ -210,6 +210,69 @@ public class KafkaCachePartitionTest
     }
 
     @Test
+    public void shouldRoundTripPaddedValueWithHeadersAndTrailersIntact() throws Exception
+    {
+        KafkaCachePartition partition = newPartition();
+        Node head = partition.append(10L);
+        MutableInteger entryMark = new MutableInteger(0);
+        MutableInteger valueMark = new MutableInteger(0);
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+
+        KafkaKeyFW key = key(buffer, "k1");
+        Array32FW<KafkaHeaderFW> headers = noHeaders(buffer, key.limit());
+        OctetsFW value = value(buffer, headers.limit(), "hello");
+
+        partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
+            key, headers, value, 0x00, KafkaDeltaType.NONE, KafkaCacheModel.NONE, KafkaCacheModel.NONE,
+            new KafkaCacheKeyEnvelope(), new KafkaCacheTrailerEnvelope(), 256, false);
+
+        KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
+
+        assertEquals(5, entry.paddedValue().length());
+        assertArrayEquals("hello".getBytes(UTF_8), bytes(entry.paddedValue().value()));
+        assertEquals(0, entry.headers().fieldCount());
+        assertEquals(0, entry.trailers().fieldCount());
+    }
+
+    @Test
+    public void shouldRoundTripNullPaddedValue() throws Exception
+    {
+        KafkaCachePartition partition = newPartition();
+        Node head = partition.append(10L);
+        MutableInteger entryMark = new MutableInteger(0);
+        MutableInteger valueMark = new MutableInteger(0);
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+
+        KafkaKeyFW key = key(buffer, "k1");
+        Array32FW<KafkaHeaderFW> headers = noHeaders(buffer, key.limit());
+
+        partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
+            key, headers, null, 0x00, KafkaDeltaType.NONE, KafkaCacheModel.NONE, KafkaCacheModel.NONE,
+            new KafkaCacheKeyEnvelope(), new KafkaCacheTrailerEnvelope(), 256, false);
+
+        KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
+
+        assertEquals(-1, entry.paddedValue().length());
+    }
+
+    @Test
+    public void shouldNotInflateHashReservationFromValuePaddingMax() throws Exception
+    {
+        Path location = tempFolder.newFolder().toPath();
+        KafkaCacheTopicConfig config = new KafkaCacheTopicConfig(new KafkaConfiguration());
+        config.segmentIndexBytes = 256;
+        KafkaCachePartition partition = new KafkaCachePartition(location, config, "cache", "test", 0, 65536, long[]::new);
+
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[64]);
+        KafkaKeyFW key = key(buffer, "k");
+
+        Node first = partition.newHeadIfNecessary(10L, key, 10, 0, 0);
+        Node second = partition.newHeadIfNecessary(11L, key, 10, 1_000_000, 0);
+
+        assertSame(first, second);
+    }
+
+    @Test
     public void shouldTransformValueWithDecodeModel() throws Exception
     {
         KafkaCachePartition partition = newPartition();
@@ -257,8 +320,10 @@ public class KafkaCachePartitionTest
         KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
         KafkaCacheModel transformValue = KafkaCacheModel.writer(paddingHandler(), ModelTransform.NONE, valueEnvelope, scratch);
 
+        int valuePaddingMax = transformValue.padding(firstFragment.buffer(), firstFragment.offset(), valueLength);
+
         int transformed = partition.writeProduceEntryStart(1L, 1L, 0L, 11L, head, entryMark, valueMark, valueLimit,
-            trailersClaimMark, 0L, 1L, -1L, (short) 0, 0, KafkaAckMode.NONE, key, valueLength, headers, 256,
+            trailersClaimMark, 0L, 1L, -1L, (short) 0, 0, KafkaAckMode.NONE, key, valueLength, valuePaddingMax, headers, 256,
             firstFragment, KafkaCacheModel.NONE, transformValue);
 
         assertNotEquals(-1, transformed);

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
@@ -21,10 +21,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
@@ -273,6 +275,191 @@ public class KafkaCachePartitionTest
     }
 
     @Test
+    public void shouldStreamTransformedValueDirectlyIntoLogFileForProduce() throws Exception
+    {
+        KafkaCachePartition partition = newPartition();
+        Node head = partition.append(10L);
+        MutableInteger entryMark = new MutableInteger(0);
+        MutableInteger valueMark = new MutableInteger(0);
+        MutableInteger valueLimit = new MutableInteger(0);
+        MutableInteger trailersClaimMark = new MutableInteger(0);
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+
+        KafkaKeyFW key = key(buffer, "k1");
+        Array32FW<KafkaHeaderFW> headers = noHeaders(buffer, key.limit());
+        OctetsFW value = value(buffer, headers.limit(), "hello");
+
+        UppercasingPipeline pipeline = new UppercasingPipeline();
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+
+        int transformed = partition.writeProduceEntryStart(1L, 1L, 0L, 11L, head, entryMark, valueMark, valueLimit,
+            trailersClaimMark, 0L, 1L, -1L, (short) 0, 0, KafkaAckMode.NONE, key, 5, 4, headers, 256,
+            value, KafkaCacheModel.NONE, transformValue);
+        assertNotEquals(-1, transformed);
+
+        int continued = partition.writeProduceEntryContinue(1L, 1L, 0L, 0x03, head, entryMark, valueMark, valueLimit,
+            value, transformValue);
+        assertNotEquals(-1, continued);
+
+        partition.writeProduceEntryFin(head, entryMark, valueLimit, 0L, noHeaders(buffer, 0), false);
+
+        KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
+        assertEquals(-1, entry.convertedPosition());
+        assertEquals(7, entry.paddedValue().length());
+        assertArrayEquals("HELLO!!".getBytes(UTF_8), bytes(entry.paddedValue().value()));
+        assertEquals(1, pipeline.resetCount);
+
+        assertFalse(containsBytes(head.segment().logFile().buffer(), entryMark.value, entry.limit() - entryMark.value,
+            "hello".getBytes(UTF_8)));
+    }
+
+    @Test
+    public void shouldStreamTransformedValueAcrossMultipleFragmentsForProduce() throws Exception
+    {
+        KafkaCachePartition partition = newPartition();
+        Node head = partition.append(10L);
+        MutableInteger entryMark = new MutableInteger(0);
+        MutableInteger valueMark = new MutableInteger(0);
+        MutableInteger valueLimit = new MutableInteger(0);
+        MutableInteger trailersClaimMark = new MutableInteger(0);
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+
+        KafkaKeyFW key = key(buffer, "k1");
+        Array32FW<KafkaHeaderFW> headers = noHeaders(buffer, key.limit());
+        OctetsFW firstFragment = value(buffer, headers.limit(), "hel");
+        OctetsFW secondFragment = value(buffer, headers.limit() + 3, "lo");
+
+        UppercasingPipeline pipeline = new UppercasingPipeline();
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+
+        int transformed = partition.writeProduceEntryStart(1L, 1L, 0L, 11L, head, entryMark, valueMark, valueLimit,
+            trailersClaimMark, 0L, 1L, -1L, (short) 0, 0, KafkaAckMode.NONE, key, 5, 4, headers, 256,
+            firstFragment, KafkaCacheModel.NONE, transformValue);
+        assertNotEquals(-1, transformed);
+
+        assertNotEquals(-1, partition.writeProduceEntryContinue(1L, 1L, 0L, 0x02, head, entryMark, valueMark, valueLimit,
+            firstFragment, transformValue));
+        assertNotEquals(-1, partition.writeProduceEntryContinue(1L, 1L, 0L, 0x01, head, entryMark, valueMark, valueLimit,
+            secondFragment, transformValue));
+
+        partition.writeProduceEntryFin(head, entryMark, valueLimit, 0L, noHeaders(buffer, 0), false);
+
+        KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
+        assertEquals(7, entry.paddedValue().length());
+        assertArrayEquals("HELLO!!".getBytes(UTF_8), bytes(entry.paddedValue().value()));
+    }
+
+    @Test
+    public void shouldAbortProduceEntryWhenTransformedValueExceedsReservation() throws Exception
+    {
+        KafkaCachePartition partition = newPartition();
+        Node head = partition.append(10L);
+        MutableInteger entryMark = new MutableInteger(0);
+        MutableInteger valueMark = new MutableInteger(0);
+        MutableInteger valueLimit = new MutableInteger(0);
+        MutableInteger trailersClaimMark = new MutableInteger(0);
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+
+        KafkaKeyFW key = key(buffer, "k1");
+        Array32FW<KafkaHeaderFW> headers = noHeaders(buffer, key.limit());
+        OctetsFW value = value(buffer, headers.limit(), "hello");
+
+        UppercasingPipeline pipeline = new UppercasingPipeline();
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+
+        partition.writeProduceEntryStart(1L, 1L, 0L, 11L, head, entryMark, valueMark, valueLimit,
+            trailersClaimMark, 0L, 1L, -1L, (short) 0, 0, KafkaAckMode.NONE, key, 5, 0, headers, 256,
+            value, KafkaCacheModel.NONE, transformValue);
+
+        partition.writeProduceEntryContinue(1L, 1L, 0L, 0x03, head, entryMark, valueMark, valueLimit,
+            value, transformValue);
+
+        int flags = head.segment().logFile().readInt(entryMark.value + KafkaCacheEntryFW.FIELD_OFFSET_FLAGS);
+        assertEquals(KafkaCachePartition.CACHE_ENTRY_FLAGS_ABORTED,
+            flags & KafkaCachePartition.CACHE_ENTRY_FLAGS_ABORTED);
+    }
+
+    private static boolean containsBytes(
+        DirectBufferEx haystack,
+        int offset,
+        int length,
+        byte[] needle)
+    {
+        outer:
+        for (int i = 0; i <= length - needle.length; i++)
+        {
+            for (int j = 0; j < needle.length; j++)
+            {
+                if (haystack.getByte(offset + i + j) != needle[j])
+                {
+                    continue outer;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    // uppercases ASCII input and appends "!!" once complete, so a test can distinguish transformed
+    // (longer, uppercase) output from the raw bytes it must never leave behind in logFile
+    private static final class UppercasingPipeline implements ModelPipeline
+    {
+        private static final int FLAGS_FIN = 0x01;
+
+        private final ModelPipelineResult result = new ModelPipelineResult();
+        private int resetCount;
+
+        @Override
+        public ModelPipelineResult transform(
+            long traceId,
+            long bindingId,
+            long authorization,
+            int flags,
+            DirectBufferEx src,
+            int srcIndex,
+            int srcLimit,
+            MutableDirectBufferEx dst,
+            int dstIndex,
+            int dstLimit)
+        {
+            final int length = srcLimit - srcIndex;
+            for (int i = 0; i < length; i++)
+            {
+                byte value = src.getByte(srcIndex + i);
+                if (value >= 'a' && value <= 'z')
+                {
+                    value -= 32;
+                }
+                dst.putByte(dstIndex + i, value);
+            }
+
+            int produced = length;
+            final boolean fin = (flags & FLAGS_FIN) != 0;
+            if (fin)
+            {
+                dst.putByte(dstIndex + length, (byte) '!');
+                dst.putByte(dstIndex + length + 1, (byte) '!');
+                produced += 2;
+            }
+
+            final ModelStatus status = fin ? ModelStatus.COMPLETE : ModelStatus.UNDERFLOW;
+            return result.set(status, length, produced);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return false;
+        }
+
+        @Override
+        public void reset()
+        {
+            resetCount++;
+        }
+    }
+
+    @Test
     public void shouldTransformValueWithDecodeModel() throws Exception
     {
         KafkaCachePartition partition = newPartition();
@@ -293,16 +480,126 @@ public class KafkaCachePartitionTest
             new KafkaCacheKeyEnvelope(), valueEnvelope, 256, false);
 
         KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
-        assertNotEquals(-1, entry.convertedPosition());
-
-        KafkaCachePaddedValueFW transformed = head.segment().convertedFile()
-            .readBytes(entry.convertedPosition(), paddedValueRO::wrap);
-        assertEquals(5, transformed.length());
-        assertArrayEquals("hello".getBytes(UTF_8), bytes(transformed.value()));
+        assertEquals(-1, entry.convertedPosition());
+        assertEquals(5, entry.paddedValue().length());
+        assertArrayEquals("hello".getBytes(UTF_8), bytes(entry.paddedValue().value()));
     }
 
     @Test
-    public void shouldSizeConvertedReservationFromFullValueLengthNotFirstFragment() throws Exception
+    public void shouldStreamTransformedValueDirectlyIntoLogFileForPopulate() throws Exception
+    {
+        KafkaCachePartition partition = newPartition();
+        Node head = partition.append(10L);
+        MutableInteger entryMark = new MutableInteger(0);
+        MutableInteger valueMark = new MutableInteger(0);
+        MutableInteger valueLimit = new MutableInteger(0);
+        MutableInteger headersMark = new MutableInteger(0);
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+
+        KafkaKeyFW key = key(buffer, "k1");
+        Array32FW<KafkaHeaderFW> headers = noHeaders(buffer, key.limit());
+        OctetsFW value = value(buffer, headers.limit(), "hello");
+
+        UppercasingPipeline pipeline = new UppercasingPipeline();
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+        KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
+
+        partition.writeEntryStart(null, 1L, 1L, 0L, 11L, entryMark, valueMark, valueLimit, headersMark, 0L,
+            KafkaTimestampType.ADVISORY, -1L, key, 5, 4, headers.sizeof(), 256, null, 0x00, KafkaDeltaType.NONE,
+            value, KafkaCacheModel.NONE, transformValue, new KafkaCacheKeyEnvelope(), valueEnvelope, false);
+
+        assertNotEquals(-1, partition.writeEntryContinue(1L, 1L, 0L, 0x03, entryMark, valueMark, valueLimit,
+            value, transformValue));
+
+        partition.writeEntryFinish(headers, KafkaDeltaType.NONE, entryMark, valueMark, headersMark, headers.sizeof(),
+            transformValue, valueEnvelope, 256);
+
+        KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
+        assertEquals(-1, entry.convertedPosition());
+        assertEquals(7, entry.paddedValue().length());
+        assertArrayEquals("HELLO!!".getBytes(UTF_8), bytes(entry.paddedValue().value()));
+        assertEquals(1, pipeline.resetCount);
+
+        assertFalse(containsBytes(head.segment().logFile().buffer(), entryMark.value, entry.limit() - entryMark.value,
+            "hello".getBytes(UTF_8)));
+    }
+
+    @Test
+    public void shouldStreamTransformedValueAcrossMultipleFragmentsForPopulate() throws Exception
+    {
+        KafkaCachePartition partition = newPartition();
+        Node head = partition.append(10L);
+        MutableInteger entryMark = new MutableInteger(0);
+        MutableInteger valueMark = new MutableInteger(0);
+        MutableInteger valueLimit = new MutableInteger(0);
+        MutableInteger headersMark = new MutableInteger(0);
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+
+        KafkaKeyFW key = key(buffer, "k1");
+        Array32FW<KafkaHeaderFW> headers = noHeaders(buffer, key.limit());
+        OctetsFW firstFragment = value(buffer, headers.limit(), "hel");
+        OctetsFW secondFragment = value(buffer, headers.limit() + 3, "lo");
+
+        UppercasingPipeline pipeline = new UppercasingPipeline();
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+        KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
+
+        partition.writeEntryStart(null, 1L, 1L, 0L, 11L, entryMark, valueMark, valueLimit, headersMark, 0L,
+            KafkaTimestampType.ADVISORY, -1L, key, 5, 4, headers.sizeof(), 256, null, 0x00, KafkaDeltaType.NONE,
+            firstFragment, KafkaCacheModel.NONE, transformValue, new KafkaCacheKeyEnvelope(), valueEnvelope, false);
+
+        assertNotEquals(-1, partition.writeEntryContinue(1L, 1L, 0L, 0x02, entryMark, valueMark, valueLimit,
+            firstFragment, transformValue));
+        assertNotEquals(-1, partition.writeEntryContinue(1L, 1L, 0L, 0x01, entryMark, valueMark, valueLimit,
+            secondFragment, transformValue));
+
+        partition.writeEntryFinish(headers, KafkaDeltaType.NONE, entryMark, valueMark, headersMark, headers.sizeof(),
+            transformValue, valueEnvelope, 256);
+
+        KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
+        assertEquals(7, entry.paddedValue().length());
+        assertArrayEquals("HELLO!!".getBytes(UTF_8), bytes(entry.paddedValue().value()));
+    }
+
+    @Test
+    public void shouldAbortEntryWhenTransformedValueExceedsReservation() throws Exception
+    {
+        KafkaCachePartition partition = newPartition();
+        Node head = partition.append(10L);
+        MutableInteger entryMark = new MutableInteger(0);
+        MutableInteger valueMark = new MutableInteger(0);
+        MutableInteger valueLimit = new MutableInteger(0);
+        MutableInteger headersMark = new MutableInteger(0);
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+
+        KafkaKeyFW key = key(buffer, "k1");
+        Array32FW<KafkaHeaderFW> headers = noHeaders(buffer, key.limit());
+        OctetsFW value = value(buffer, headers.limit(), "hello");
+
+        UppercasingPipeline pipeline = new UppercasingPipeline();
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+        KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
+
+        partition.writeEntryStart(null, 1L, 1L, 0L, 11L, entryMark, valueMark, valueLimit, headersMark, 0L,
+            KafkaTimestampType.ADVISORY, -1L, key, 5, 0, headers.sizeof(), 256, null, 0x00, KafkaDeltaType.NONE,
+            value, KafkaCacheModel.NONE, transformValue, new KafkaCacheKeyEnvelope(), valueEnvelope, false);
+
+        partition.writeEntryContinue(1L, 1L, 0L, 0x03, entryMark, valueMark, valueLimit, value, transformValue);
+
+        partition.writeEntryFinish(headers, KafkaDeltaType.NONE, entryMark, valueMark, headersMark, headers.sizeof(),
+            transformValue, valueEnvelope, 256);
+
+        int flags = head.segment().logFile().readInt(entryMark.value + KafkaCacheEntryFW.FIELD_OFFSET_FLAGS);
+        assertEquals(KafkaCachePartition.CACHE_ENTRY_FLAGS_ABORTED,
+            flags & KafkaCachePartition.CACHE_ENTRY_FLAGS_ABORTED);
+
+        KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
+        assertEquals(0, entry.headers().sizeof() - headers.sizeof());
+        assertTrue(entry.trailers().isEmpty());
+    }
+
+    @Test
+    public void shouldSizeValueReservationFromFullValueLengthNotFirstFragment() throws Exception
     {
         KafkaCachePartition partition = newPartition();
         Node head = partition.append(10L);
@@ -322,18 +619,13 @@ public class KafkaCachePartitionTest
 
         int valuePaddingMax = transformValue.padding(firstFragment.buffer(), firstFragment.offset(), valueLength);
 
-        int transformed = partition.writeProduceEntryStart(1L, 1L, 0L, 11L, head, entryMark, valueMark, valueLimit,
+        partition.writeProduceEntryStart(1L, 1L, 0L, 11L, head, entryMark, valueMark, valueLimit,
             trailersClaimMark, 0L, 1L, -1L, (short) 0, 0, KafkaAckMode.NONE, key, valueLength, valuePaddingMax, headers, 256,
             firstFragment, KafkaCacheModel.NONE, transformValue);
 
-        assertNotEquals(-1, transformed);
-
-        KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
-        int convertedAt = entry.convertedPosition();
-        assertNotEquals(-1, convertedAt);
-
-        int convertedMaxLength = head.segment().convertedFile().readInt(convertedAt + Integer.BYTES);
-        assertEquals(valueLength + valueLength * 2, convertedMaxLength);
+        final int paddingLenAt = valueMark.value + valueLength;
+        final int reservedPadding = head.segment().logFile().readInt(paddingLenAt);
+        assertEquals(valueLength * 2, reservedPadding);
     }
 
     @Test

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
@@ -38,6 +38,7 @@ import io.aklivity.zilla.config.engine.test.internal.model.config.TestModelConfi
 import io.aklivity.zilla.runtime.binding.kafka.internal.KafkaConfiguration;
 import io.aklivity.zilla.runtime.binding.kafka.internal.cache.KafkaCachePartition.Node;
 import io.aklivity.zilla.runtime.binding.kafka.internal.types.Array32FW;
+import io.aklivity.zilla.runtime.binding.kafka.internal.types.KafkaAckMode;
 import io.aklivity.zilla.runtime.binding.kafka.internal.types.KafkaDeltaType;
 import io.aklivity.zilla.runtime.binding.kafka.internal.types.KafkaHeaderFW;
 import io.aklivity.zilla.runtime.binding.kafka.internal.types.KafkaKeyFW;
@@ -235,6 +236,39 @@ public class KafkaCachePartitionTest
             .readBytes(entry.convertedPosition(), paddedValueRO::wrap);
         assertEquals(5, transformed.length());
         assertArrayEquals("hello".getBytes(UTF_8), bytes(transformed.value()));
+    }
+
+    @Test
+    public void shouldSizeConvertedReservationFromFullValueLengthNotFirstFragment() throws Exception
+    {
+        KafkaCachePartition partition = newPartition();
+        Node head = partition.append(10L);
+        MutableInteger entryMark = new MutableInteger(0);
+        MutableInteger valueMark = new MutableInteger(0);
+        MutableInteger valueLimit = new MutableInteger(0);
+        MutableInteger trailersClaimMark = new MutableInteger(0);
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+
+        KafkaKeyFW key = key(buffer, "k1");
+        Array32FW<KafkaHeaderFW> headers = noHeaders(buffer, key.limit());
+        OctetsFW firstFragment = value(buffer, headers.limit(), "he");
+        int valueLength = 5;
+
+        KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
+        KafkaCacheModel transformValue = KafkaCacheModel.writer(paddingHandler(), ModelTransform.NONE, valueEnvelope, scratch);
+
+        int transformed = partition.writeProduceEntryStart(1L, 1L, 0L, 11L, head, entryMark, valueMark, valueLimit,
+            trailersClaimMark, 0L, 1L, -1L, (short) 0, 0, KafkaAckMode.NONE, key, valueLength, headers, 256,
+            firstFragment, KafkaCacheModel.NONE, transformValue);
+
+        assertNotEquals(-1, transformed);
+
+        KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
+        int convertedAt = entry.convertedPosition();
+        assertNotEquals(-1, convertedAt);
+
+        int convertedMaxLength = head.segment().convertedFile().readInt(convertedAt + Integer.BYTES);
+        assertEquals(valueLength + valueLength * 2, convertedMaxLength);
     }
 
     @Test
@@ -550,6 +584,31 @@ public class KafkaCachePartitionTest
         return handler(pathsAndValues);
     }
 
+    // a model whose declared framing padding scales with the length it is given, so a test can prove a
+    // reservation is sized from the full declared value length, not just the first DATA fragment
+    private static ModelHandler paddingHandler()
+    {
+        return new ModelHandler()
+        {
+            @Override
+            public ModelPipeline supplyDecoder(
+                ModelEnvelope envelope,
+                ModelTransform transform,
+                ModelCache cache)
+            {
+                return new PaddingPipeline();
+            }
+
+            @Override
+            public ModelPipeline supplyEncoder(
+                ModelEnvelope envelope,
+                ModelTransform transform)
+            {
+                return supplyDecoder(envelope, transform, ModelCache.NONE);
+            }
+        };
+    }
+
     private static ModelHandler handler(
         String[] pathsAndValues)
     {
@@ -663,6 +722,47 @@ public class KafkaCachePartitionTest
             bridge.end();
 
             return result.set(ModelStatus.COMPLETE, srcLength, srcLength);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return false;
+        }
+
+        @Override
+        public void reset()
+        {
+        }
+    }
+
+    // a pipeline whose declared padding scales with the length it is given, so a test can distinguish a
+    // reservation sized from the first DATA fragment's length from one sized from the full declared value
+    private static final class PaddingPipeline implements ModelPipeline
+    {
+        @Override
+        public ModelPipelineResult transform(
+            long traceId,
+            long bindingId,
+            long authorization,
+            int flags,
+            DirectBufferEx src,
+            int srcIndex,
+            int srcLimit,
+            MutableDirectBufferEx dst,
+            int dstIndex,
+            int dstLimit)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int padding(
+            DirectBufferEx data,
+            int index,
+            int length)
+        {
+            return length * 2;
         }
 
         @Override

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
@@ -298,7 +298,7 @@ public class KafkaCachePartitionTest
         assertNotEquals(-1, transformed);
 
         int continued = partition.writeProduceEntryContinue(1L, 1L, 0L, 0x03, head, entryMark, valueMark, valueLimit,
-            value, transformValue);
+            value, transformValue, 4);
         assertNotEquals(-1, continued);
 
         partition.writeProduceEntryFin(head, entryMark, valueLimit, 0L, noHeaders(buffer, 0), false);
@@ -337,9 +337,9 @@ public class KafkaCachePartitionTest
         assertNotEquals(-1, transformed);
 
         assertNotEquals(-1, partition.writeProduceEntryContinue(1L, 1L, 0L, 0x02, head, entryMark, valueMark, valueLimit,
-            firstFragment, transformValue));
+            firstFragment, transformValue, 4));
         assertNotEquals(-1, partition.writeProduceEntryContinue(1L, 1L, 0L, 0x01, head, entryMark, valueMark, valueLimit,
-            secondFragment, transformValue));
+            secondFragment, transformValue, 4));
 
         partition.writeProduceEntryFin(head, entryMark, valueLimit, 0L, noHeaders(buffer, 0), false);
 
@@ -371,11 +371,105 @@ public class KafkaCachePartitionTest
             value, KafkaCacheModel.NONE, transformValue);
 
         partition.writeProduceEntryContinue(1L, 1L, 0L, 0x03, head, entryMark, valueMark, valueLimit,
-            value, transformValue);
+            value, transformValue, 0);
 
         int flags = head.segment().logFile().readInt(entryMark.value + KafkaCacheEntryFW.FIELD_OFFSET_FLAGS);
         assertEquals(KafkaCachePartition.CACHE_ENTRY_FLAGS_ABORTED,
             flags & KafkaCachePartition.CACHE_ENTRY_FLAGS_ABORTED);
+    }
+
+    @Test
+    public void shouldPersistValuePaddingMaxAcrossInitEmptyAndFinEmptyFragmentsForProduce() throws Exception
+    {
+        KafkaCachePartition partition = newPartition();
+        Node head = partition.append(10L);
+        MutableInteger entryMark = new MutableInteger(0);
+        MutableInteger valueMark = new MutableInteger(0);
+        MutableInteger valueLimit = new MutableInteger(0);
+        MutableInteger trailersClaimMark = new MutableInteger(0);
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+
+        KafkaKeyFW key = key(buffer, "k1");
+        Array32FW<KafkaHeaderFW> headers = noHeaders(buffer, key.limit());
+        OctetsFW emptyValue = value(buffer, headers.limit(), "");
+        OctetsFW payload = value(buffer, headers.limit(), "hello");
+
+        DoublingPipeline pipeline = new DoublingPipeline();
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+
+        final int valuePaddingMax = 8;
+        partition.writeProduceEntryStart(1L, 1L, 0L, 11L, head, entryMark, valueMark, valueLimit,
+            trailersClaimMark, 0L, 1L, -1L, (short) 0, 0, KafkaAckMode.NONE, key, 5, valuePaddingMax, headers, 256,
+            emptyValue, KafkaCacheModel.NONE, transformValue);
+
+        // the real HTTP-to-Kafka produce path splits a value across an INIT-flagged fragment with an
+        // empty payload, one or more fragments carrying the real bytes, and a FIN-flagged fragment with
+        // an empty payload -- reproduce that split here
+        assertNotEquals(-1, partition.writeProduceEntryContinue(1L, 1L, 0L, 0x02, head, entryMark, valueMark, valueLimit,
+            emptyValue, transformValue, valuePaddingMax));
+
+        // this fragment's doubled output (10 bytes) writes past the 5-byte raw-value reservation, into
+        // the on-disk valuePaddingMax marker's own position -- corrupting it if a later fragment
+        // re-derived valuePaddingMax from disk instead of being handed it directly
+        assertNotEquals(-1, partition.writeProduceEntryContinue(1L, 1L, 0L, 0x00, head, entryMark, valueMark, valueLimit,
+            payload, transformValue, valuePaddingMax));
+
+        assertNotEquals(-1, partition.writeProduceEntryContinue(1L, 1L, 0L, 0x01, head, entryMark, valueMark, valueLimit,
+            emptyValue, transformValue, valuePaddingMax));
+
+        partition.writeProduceEntryFin(head, entryMark, valueLimit, 0L, noHeaders(buffer, 0), false);
+
+        final int actualLength = 10;
+        final int finalPaddingLenAt = valueMark.value + actualLength;
+        final int finalPaddingLen = head.segment().logFile().readInt(finalPaddingLenAt);
+        assertEquals(5 + valuePaddingMax - actualLength, finalPaddingLen);
+
+        KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
+        assertEquals(actualLength, entry.paddedValue().length());
+        assertArrayEquals("hheelllloo".getBytes(UTF_8), bytes(entry.paddedValue().value()));
+    }
+
+    @Test
+    public void shouldPersistValuePaddingMaxAcrossInitEmptyAndFinEmptyFragmentsForPopulate() throws Exception
+    {
+        KafkaCachePartition partition = newPartition();
+        Node head = partition.append(10L);
+        MutableInteger entryMark = new MutableInteger(0);
+        MutableInteger valueMark = new MutableInteger(0);
+        MutableInteger valueLimit = new MutableInteger(0);
+        MutableInteger headersMark = new MutableInteger(0);
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+
+        KafkaKeyFW key = key(buffer, "k1");
+        Array32FW<KafkaHeaderFW> headers = noHeaders(buffer, key.limit());
+        OctetsFW emptyValue = value(buffer, headers.limit(), "");
+        OctetsFW payload = value(buffer, headers.limit(), "hello");
+
+        DoublingPipeline pipeline = new DoublingPipeline();
+        KafkaCacheModel transformValue = new KafkaCacheModel(pipeline, scratch);
+        KafkaCacheTrailerEnvelope valueEnvelope = new KafkaCacheTrailerEnvelope();
+
+        final int valuePaddingMax = 8;
+        partition.writeEntryStart(null, 1L, 1L, 0L, 11L, entryMark, valueMark, valueLimit, headersMark, 0L,
+            KafkaTimestampType.ADVISORY, -1L, key, 5, valuePaddingMax, headers.sizeof(), 256, null, 0x00,
+            KafkaDeltaType.NONE, emptyValue, KafkaCacheModel.NONE, transformValue, new KafkaCacheKeyEnvelope(),
+            valueEnvelope, false);
+
+        assertNotEquals(-1, partition.writeEntryContinue(1L, 1L, 0L, 0x02, entryMark, valueMark, valueLimit,
+            emptyValue, transformValue, valuePaddingMax));
+        assertNotEquals(-1, partition.writeEntryContinue(1L, 1L, 0L, 0x00, entryMark, valueMark, valueLimit,
+            payload, transformValue, valuePaddingMax));
+        assertNotEquals(-1, partition.writeEntryContinue(1L, 1L, 0L, 0x01, entryMark, valueMark, valueLimit,
+            emptyValue, transformValue, valuePaddingMax));
+
+        partition.writeEntryFinish(headers, KafkaDeltaType.NONE, entryMark, valueMark, headersMark, headers.sizeof(),
+            transformValue, valueEnvelope, 256);
+
+        KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
+        assertEquals(10, entry.paddedValue().length());
+        assertArrayEquals("hheelllloo".getBytes(UTF_8), bytes(entry.paddedValue().value()));
+        assertEquals(0, entry.headers().fieldCount());
+        assertEquals(0, entry.trailers().fieldCount());
     }
 
     private static boolean containsBytes(
@@ -458,6 +552,54 @@ public class KafkaCachePartitionTest
         }
     }
 
+    // doubles every input byte, so a fragment's output can exceed the raw-value reservation entirely
+    // within that one fragment -- a test can then split an empty INIT fragment, this fragment, and an
+    // empty FIN fragment across three separate calls to prove valuePaddingMax survives the split
+    private static final class DoublingPipeline implements ModelPipeline
+    {
+        private static final int FLAGS_FIN = 0x01;
+
+        private final ModelPipelineResult result = new ModelPipelineResult();
+
+        @Override
+        public ModelPipelineResult transform(
+            long traceId,
+            long bindingId,
+            long authorization,
+            int flags,
+            DirectBufferEx src,
+            int srcIndex,
+            int srcLimit,
+            MutableDirectBufferEx dst,
+            int dstIndex,
+            int dstLimit)
+        {
+            final int length = srcLimit - srcIndex;
+            for (int i = 0; i < length; i++)
+            {
+                byte value = src.getByte(srcIndex + i);
+                dst.putByte(dstIndex + i * 2, value);
+                dst.putByte(dstIndex + i * 2 + 1, value);
+            }
+
+            final int produced = length * 2;
+            final boolean fin = (flags & FLAGS_FIN) != 0;
+            final ModelStatus status = fin ? ModelStatus.COMPLETE : ModelStatus.UNDERFLOW;
+            return result.set(status, length, produced);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return false;
+        }
+
+        @Override
+        public void reset()
+        {
+        }
+    }
+
     @Test
     public void shouldTransformValueWithDecodeModel() throws Exception
     {
@@ -507,7 +649,7 @@ public class KafkaCachePartitionTest
             value, KafkaCacheModel.NONE, transformValue, new KafkaCacheKeyEnvelope(), valueEnvelope, false);
 
         assertNotEquals(-1, partition.writeEntryContinue(1L, 1L, 0L, 0x03, entryMark, valueMark, valueLimit,
-            value, transformValue));
+            value, transformValue, 4));
 
         partition.writeEntryFinish(headers, KafkaDeltaType.NONE, entryMark, valueMark, headersMark, headers.sizeof(),
             transformValue, valueEnvelope, 256);
@@ -546,9 +688,9 @@ public class KafkaCachePartitionTest
             firstFragment, KafkaCacheModel.NONE, transformValue, new KafkaCacheKeyEnvelope(), valueEnvelope, false);
 
         assertNotEquals(-1, partition.writeEntryContinue(1L, 1L, 0L, 0x02, entryMark, valueMark, valueLimit,
-            firstFragment, transformValue));
+            firstFragment, transformValue, 4));
         assertNotEquals(-1, partition.writeEntryContinue(1L, 1L, 0L, 0x01, entryMark, valueMark, valueLimit,
-            secondFragment, transformValue));
+            secondFragment, transformValue, 4));
 
         partition.writeEntryFinish(headers, KafkaDeltaType.NONE, entryMark, valueMark, headersMark, headers.sizeof(),
             transformValue, valueEnvelope, 256);
@@ -581,7 +723,7 @@ public class KafkaCachePartitionTest
             KafkaTimestampType.ADVISORY, -1L, key, 5, 0, headers.sizeof(), 256, null, 0x00, KafkaDeltaType.NONE,
             value, KafkaCacheModel.NONE, transformValue, new KafkaCacheKeyEnvelope(), valueEnvelope, false);
 
-        partition.writeEntryContinue(1L, 1L, 0L, 0x03, entryMark, valueMark, valueLimit, value, transformValue);
+        partition.writeEntryContinue(1L, 1L, 0L, 0x03, entryMark, valueMark, valueLimit, value, transformValue, 0);
 
         partition.writeEntryFinish(headers, KafkaDeltaType.NONE, entryMark, valueMark, headersMark, headers.sizeof(),
             transformValue, valueEnvelope, 256);

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
@@ -304,7 +304,6 @@ public class KafkaCachePartitionTest
         partition.writeProduceEntryFin(head, entryMark, valueLimit, 0L, noHeaders(buffer, 0), false);
 
         KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
-        assertEquals(-1, entry.convertedPosition());
         assertEquals(7, entry.paddedValue().length());
         assertArrayEquals("HELLO!!".getBytes(UTF_8), bytes(entry.paddedValue().value()));
         assertEquals(1, pipeline.resetCount);
@@ -480,7 +479,6 @@ public class KafkaCachePartitionTest
             new KafkaCacheKeyEnvelope(), valueEnvelope, 256, false);
 
         KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
-        assertEquals(-1, entry.convertedPosition());
         assertEquals(5, entry.paddedValue().length());
         assertArrayEquals("hello".getBytes(UTF_8), bytes(entry.paddedValue().value()));
     }
@@ -515,7 +513,6 @@ public class KafkaCachePartitionTest
             transformValue, valueEnvelope, 256);
 
         KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
-        assertEquals(-1, entry.convertedPosition());
         assertEquals(7, entry.paddedValue().length());
         assertArrayEquals("HELLO!!".getBytes(UTF_8), bytes(entry.paddedValue().value()));
         assertEquals(1, pipeline.resetCount);

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheSegmentTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheSegmentTest.java
@@ -16,10 +16,13 @@
 package io.aklivity.zilla.runtime.binding.kafka.internal.cache;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,6 +61,11 @@ public class KafkaCacheSegmentTest
             assertEquals(head.hashFile().capacity(), tail.hashFile().capacity());
             assertNotEquals(head.keysFile().location(), tail.keysFile().location());
             assertEquals(head.keysFile().capacity(), tail.keysFile().capacity());
+
+            try (Stream<Path> files = Files.list(location))
+            {
+                assertFalse(files.anyMatch(p -> p.getFileName().toString().endsWith(".converted")));
+            }
         }
     }
 

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheProduceIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheProduceIT.java
@@ -388,6 +388,22 @@ public class CacheProduceIT
         k3po.finish();
     }
 
+    // regression coverage for zilla#2461: a real protobuf value model, encoding the client's raw
+    // protobuf bytes with an INIT-flagged fragment carrying no bytes yet (declaring the full length
+    // via deferred()) followed by a FIN-flagged fragment carrying every byte -- the split the real
+    // HTTP-to-Kafka produce mapping uses, and the shape that exposed writeProduceEntryContinue
+    // re-deriving valuePaddingMax from a disk position the catalog framing had already overwritten
+    @Test
+    @Configuration("cache.value.model.protobuf.yaml")
+    @Specification({
+        "${app}/message.value.protobuf.fragmented/client",
+        "${app}/message.value.protobuf.fragmented/server"})
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldSendMessageValueProtobufFragmented() throws Exception
+    {
+        k3po.finish();
+    }
+
     // proves a message whose envelope-collected trailer entries exceed the block claimed for them
     // (cache.client.trailers.size.max, deliberately sized to fit only the first of two configured
     // fields) drops the entry that overflows rather than corrupting or silently discarding everything

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
@@ -65,6 +65,7 @@ final class AvroPipelineImpl implements AvroPipeline
 
     private boolean suspended;
     private AvroEvent suspendedEvent;
+    private boolean completed;
 
     AvroPipelineImpl(
         AvroParser parser,
@@ -91,6 +92,7 @@ final class AvroPipelineImpl implements AvroPipeline
         parser.reset();
         root.reset();
         suspended = false;
+        completed = false;
         diagnostic.message = null;
     }
 
@@ -120,6 +122,15 @@ final class AvroPipelineImpl implements AvroPipeline
         int limit,
         boolean last)
     {
+        if (completed && offset == limit)
+        {
+            // the datum already finished on an earlier call (root reported COMPLETED before this window
+            // arrived) and the parser was left at Phase.DONE rather than reset -- this window is the
+            // caller's own separate, empty trailing confirmation for the same datum (e.g. a FIN-flagged
+            // fragment carrying no further bytes), not the start of a new one, so report COMPLETED again
+            // without re-driving the parser rather than letting it fall through to STARVED
+            return COMPLETED;
+        }
         Status status = ADVANCED;
         AvroEvent event = null;
         try
@@ -172,6 +183,7 @@ final class AvroPipelineImpl implements AvroPipeline
             reporter.rejected(diagnostic);
         }
         suspended = status == SUSPENDED;
+        completed = status == COMPLETED;
         // the pump remembers which event suspended (so the sink keeps no resume state); a re-suspend on
         // resume leaves event null, keeping the prior suspendedEvent
         if (suspended && event != null)

--- a/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroPipelineTransformTest.java
+++ b/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroPipelineTransformTest.java
@@ -152,6 +152,39 @@ class AvroPipelineTransformTest
         assertArrayEquals(new byte[] { 0x02, 0x04, 0x68, 0x69 }, drained.toByteArray());
     }
 
+    @Test
+    void shouldCompleteOnEmptyFinalWindowAfterWholeDatumConsumed()
+    {
+        AvroSchema schema = Avro.schema("""
+            {"type":"record","name":"R","fields":[
+            {"name":"id","type":"int"},
+            {"name":"name","type":"string"}]}""");
+        AvroPipeline pipeline = Avro.stream(Avro.parser(schema))
+            .transform(schema.validator())
+            .into(generatorFor(schema));
+        pipeline.reset();
+
+        // id=1 (0x02), name="hi" (0x04 0x68 0x69) -- the whole datum arrives in the first, non-final window;
+        // the caller's own FIN still arrives as a separate, empty final window (the real produce/populate
+        // mapping always sends one), reproducing zilla#2461's INIT-empty/payload/FIN-empty split
+        byte[] whole = { 0x02, 0x04, 0x68, 0x69 };
+        byte[] empty = { };
+        int dstCap = 64;
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[DST_OFFSET + dstCap]);
+        ByteArrayOutputStream drained = new ByteArrayOutputStream();
+
+        AvroPipelineResult first = pipeline.transform(srcOf(whole), SRC_OFFSET, SRC_OFFSET + whole.length, false,
+            dst, DST_OFFSET, DST_OFFSET + dstCap);
+        drainChunk(dst, first.produced(), drained);
+
+        AvroPipelineResult second = pipeline.transform(srcOf(empty), SRC_OFFSET, SRC_OFFSET + empty.length, true,
+            dst, DST_OFFSET, DST_OFFSET + dstCap);
+        assertEquals(Status.COMPLETED, second.status());
+        drainChunk(dst, second.produced(), drained);
+
+        assertArrayEquals(whole, drained.toByteArray());
+    }
+
     private static AvroGenerator generatorFor(
         AvroSchema schema)
     {

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -57,6 +57,7 @@ public final class JsonPipelineImpl implements JsonPipeline
     private final boolean lenient;
 
     private boolean suspended;
+    private boolean completed;
     // the value event in flight across a suspend, handed to root.resume() so no stage stores it
     private JsonEvent resumeEvent;
 
@@ -86,6 +87,7 @@ public final class JsonPipelineImpl implements JsonPipeline
         parser.reset();
         root.reset();
         suspended = false;
+        completed = false;
         diagnostic.message = null;
         resumeEvent = null;
     }
@@ -116,6 +118,15 @@ public final class JsonPipelineImpl implements JsonPipeline
         int limit,
         boolean last)
     {
+        if (completed && offset == limit)
+        {
+            // the document already finished on an earlier call (self-delimited by its closing token, before
+            // this window arrived) and the parser was left at end-of-document rather than reset -- this
+            // window is the caller's own separate, empty trailing confirmation for the same document (e.g. a
+            // FIN-flagged fragment carrying no further bytes), not the start of a new one, so report
+            // COMPLETED again without re-driving the parser rather than letting it fall through to REJECTED
+            return Status.COMPLETED;
+        }
         Status status = Status.ADVANCED;
         try
         {
@@ -202,6 +213,7 @@ public final class JsonPipelineImpl implements JsonPipeline
             reporter.rejected(diagnostic);
         }
         suspended = status == Status.SUSPENDED;
+        completed = status == Status.COMPLETED;
         return status;
     }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineTransformTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineTransformTest.java
@@ -150,6 +150,33 @@ class JsonPipelineTransformTest
     }
 
     @Test
+    void shouldCompleteOnEmptyFinalWindowAfterWholeDocumentConsumed()
+    {
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonEx.createGenerator());
+        pipeline.reset();
+
+        // the whole document (self-delimited by its closing brace) arrives in the first, non-final window;
+        // the caller's own FIN still arrives as a separate, empty final window (the real produce/populate
+        // mapping always sends one), reproducing zilla#2461's INIT-empty/payload/FIN-empty split
+        byte[] whole = "{\"a\":1}".getBytes(UTF_8);
+        byte[] empty = { };
+        int dstCap = 64;
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[DST_OFFSET + dstCap]);
+        ByteArrayOutputStream drained = new ByteArrayOutputStream();
+
+        JsonPipelineResult first = pipeline.transform(srcOf(whole), SRC_OFFSET, SRC_OFFSET + whole.length, false,
+            dst, DST_OFFSET, DST_OFFSET + dstCap);
+        drainChunk(dst, first.produced(), drained);
+
+        JsonPipelineResult second = pipeline.transform(srcOf(empty), SRC_OFFSET, SRC_OFFSET + empty.length, true,
+            dst, DST_OFFSET, DST_OFFSET + dstCap);
+        assertEquals(Status.COMPLETED, second.status());
+        drainChunk(dst, second.produced(), drained);
+
+        assertEquals("{\"a\":1}", drained.toString(UTF_8));
+    }
+
+    @Test
     void shouldReportIdentityForVerbatimPipeline()
     {
         JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(JsonEx.createGenerator());

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineTransformTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineTransformTest.java
@@ -138,6 +138,40 @@ class ProtobufPipelineTransformTest
     }
 
     @Test
+    void shouldCompleteOnEmptyFinalWindowAfterWholeMessageConsumed()
+    {
+        ProtobufPipeline pipeline = Protobuf.stream(Protobuf.parser()).into(Protobuf.generator());
+        pipeline.reset();
+
+        // the whole message arrives in the first, non-final window; the caller's own FIN still arrives as a
+        // separate, empty final window (the real produce/populate mapping always sends one), reproducing
+        // zilla#2461's INIT-empty/payload/FIN-empty split
+        byte[] whole = wire(w ->
+        {
+            w.writeTag(1, ProtobufWireType.VARINT);
+            w.writeVarint64(5);
+            w.writeTag(2, ProtobufWireType.LEN);
+            w.writeBytes("hi".getBytes(UTF_8));
+        });
+        byte[] empty = { };
+        int dstCap = 64;
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[DST_OFFSET + dstCap]);
+        ByteArrayOutputStream drained = new ByteArrayOutputStream();
+
+        ProtobufPipelineResult first = pipeline.transform(srcOf(whole), SRC_OFFSET, SRC_OFFSET + whole.length, false,
+            dst, DST_OFFSET, DST_OFFSET + dstCap);
+        assertEquals(Status.STARVED, first.status());
+        drainChunk(dst, first.produced(), drained);
+
+        ProtobufPipelineResult second = pipeline.transform(srcOf(empty), SRC_OFFSET, SRC_OFFSET + empty.length, true,
+            dst, DST_OFFSET, DST_OFFSET + dstCap);
+        assertEquals(Status.COMPLETED, second.status());
+        drainChunk(dst, second.produced(), drained);
+
+        assertArrayEquals(whole, drained.toByteArray());
+    }
+
+    @Test
     void shouldReportIdentityForWirePipeline()
     {
         ProtobufSchema schema = newSchema();

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
@@ -138,6 +138,32 @@ public class AvroModelDecoderPipelineTest
         assertEquals(JSON, outA.toString(UTF_8));
     }
 
+    // regression coverage for zilla#2461's INIT-empty/payload/FIN-empty produce/populate fragmentation
+    // pattern: an INIT-flagged fragment carrying the whole value (declaring its length via zero remaining
+    // bytes upstream, not modeled here since the decoder itself is oblivious to deferred()), followed by a
+    // truly empty FIN-flagged fragment -- the real mapping always sends one, even when nothing is left
+    @Test
+    public void shouldCompleteOnEmptyFinAfterWholeValueConsumed()
+    {
+        AvroModelHandlerImpl handler = newHandler();
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE, ModelCache.NONE);
+
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        ByteArrayOutputStream drained = new ByteArrayOutputStream();
+
+        ModelPipelineResult first = pipeline.transform(0L, 0L, 0L, FLAGS_INIT,
+            new UnsafeBufferEx(AVRO), 0, AVRO.length, dst, 0, dst.capacity());
+        drain(dst, first.produced(), drained);
+
+        byte[] empty = { };
+        ModelPipelineResult second = pipeline.transform(0L, 0L, 0L, FLAGS_FIN,
+            new UnsafeBufferEx(empty), 0, empty.length, dst, 0, dst.capacity());
+        assertEquals(ModelStatus.COMPLETE, second.status());
+        drain(dst, second.produced(), drained);
+
+        assertEquals(JSON, drained.toString(UTF_8));
+    }
+
     @Test
     public void shouldExtractField()
     {

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.value.model.protobuf.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.value.model.protobuf.yaml
@@ -1,0 +1,53 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: test
+catalogs:
+  test0:
+    type: test
+    options:
+      id: 1
+      schema: |
+        syntax = "proto3";
+        message Request {
+            string message = 1;
+            int32 count = 2;
+        }
+bindings:
+    app0:
+        type: kafka
+        kind: cache_client
+        options:
+            topics:
+                - name: test
+                  value:
+                      model: protobuf
+                      catalog:
+                          test0:
+                              - id: 1
+                                record: Request
+        routes:
+            - exit: cache0
+              when:
+                  - topic: test
+    cache0:
+        type: kafka
+        kind: cache_server
+        routes:
+            - exit: app1
+              when:
+                  - topic: test

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.protobuf.fragmented/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.protobuf.fragmented/client.rpt
@@ -1,0 +1,91 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property deltaMillis 0L
+property newTimestamp ${kafka:timestamp() + deltaMillis}
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:dataEx()
+                             .typeId(zilla:id("kafka"))
+                             .meta()
+                                 .partition(0, 177)
+                                 .build()
+                             .build()}
+
+read notify ROUTED_BROKER_CLIENT
+
+connect await ROUTED_BROKER_CLIENT
+        "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+    option zilla:affinity 0xb1
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .produce()
+                                   .topic("test")
+                                   .partition(0)
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .topic("test")
+                                  .partition(0)
+                                  .build()
+                              .build()}
+
+write option zilla:flags 0x02
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .deferred(16)
+                                  .timestamp(newTimestamp)
+                                  .build()
+                              .build()}
+write zilla:data.empty
+
+write option zilla:flags 0x01
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .build()
+                              .build()}
+# protobuf-encoded Request{ message: "Hello, world", count: 10 }
+write [0x0a 0x0c 0x48 0x65 0x6c 0x6c 0x6f 0x2c 0x20 0x77 0x6f 0x72 0x6c 0x64 0x10 0x0a]
+write flush

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.protobuf.fragmented/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.protobuf.fragmented/server.rpt
@@ -1,0 +1,77 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .partition(0, 177)
+                                  .build()
+                              .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .topic("test")
+                                  .partition(0)
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .produce()
+                                   .topic("test")
+                                   .partition(0)
+                                   .build()
+                               .build()}
+write flush
+
+read option zilla:flags 0x03
+read zilla:data.ext ${kafka:matchDataEx()
+                             .typeId(zilla:id("kafka"))
+                             .produce()
+                                 .build()
+                             .build()}
+read [0x00 0x0a 0x0c 0x48 0x65 0x6c 0x6c 0x6f 0x2c 0x20 0x77 0x6f 0x72 0x6c 0x64 0x10 0x0a]

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/ProduceIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/ProduceIT.java
@@ -401,6 +401,12 @@ public class ProduceIT
     // cache.client.trailers.size.max that only a live engine configuration can supply. The scenario is
     // still fully covered by CacheProduceIT#shouldSendMessageValueEnvelopeOverflow.
 
+    // message.value.protobuf.fragmented has no peer-to-peer counterpart here: the server script expects
+    // the catalog-framed protobuf bytes a real protobuf value model produces during encode, which only
+    // happens inside a live Zilla engine -- there is nothing for a client/server pairing to verify
+    // without one. The scenario is still fully covered by
+    // CacheProduceIT#shouldSendMessageValueProtobufFragmented, which drives it through a live engine.
+
     @Test
     @Specification({
         "${app}/message.value.rejected/client",


### PR DESCRIPTION
## Description

On both the produce path (`KafkaCacheClientProduceFactory`) and the populate path (`KafkaCacheServerFetchFactory`), a cache entry's raw value bytes were written into `logFile`'s value region unconditionally, per DATA fragment, as they arrived. Only at FIN did a configured value model's transform run — once, over the complete raw value read back out of `logFile` — writing its output into a separate per-segment file, `convertedFile`. Downstream fetch/cursor logic redirected reads to `convertedFile`'s content whenever an entry had a valid `convertedPosition()`.

The gap (#1688): a value model configured to transform sensitive content (e.g. a redaction/tokenization/encryption model for regulated fields) still left the *original, untransformed* bytes sitting at rest in the `.log` segment file, even though the API layer never served them.

This closes that gap by making the value's own on-disk field the transform's only destination:

- **`KafkaCacheModel.transform(...)`** becomes genuinely incremental — callable once per DATA fragment as bytes stream in (`UNDERFLOW`/`COMPLETE`/`REJECTED`), rather than once at FIN over an already-fully-buffered value, with a small carry-over buffer retaining any unconsumed tail across fragments.
- **`KafkaCacheEntry`'s value field** is widened to reuse the existing `KafkaCachePaddedValue` struct (already used for `paddedKey`), so the entry's own value region can be reserved up front and finalized in place once a transform's real output length is known — mirroring how `paddedKey` already handles a transformed key.
- **The transform's output now streams directly into that reservation** as fragments arrive, on both paths — plaintext never touches `logFile` when a value model is configured. The populate path additionally has to pre-claim a header-extraction envelope's scratch space before headers are known (fragments arrive well before FIN), solved by reserving a combined headers-worst-case + trailers-sized block up front and reusing it in place at finalize time.
- **`convertedFile` is deleted entirely** — the file format, its `KafkaCacheSegment` plumbing, the cursor's value-splicing step, and the now-dead `convertedPosition` field on `KafkaCacheEntry` — along with refreshing `runtime/binding-kafka/AGENTS.md`'s stale `KafkaPipeline` section (already-removed classes from an earlier refactor) with a description of the current transform/envelope architecture.

Filter semantics are unaffected: no `KafkaFilterCondition` implementation reads an entry's value, only its key/headers.

### Test plan

- Test-first throughout: each stage added/updated unit tests before implementation and confirmed they failed for the right reason first (a compile failure against a not-yet-generated flyweight accessor, or a runtime assertion against the old `convertedFile`-based behavior).
- New/updated coverage in `KafkaCacheModelTest` (incremental transform: multi-fragment completion, reset-on-FIN/reject, UNDERFLOW-at-FIN treated as REJECTED) and `KafkaCachePartitionTest` (padded-value round trip, hash-reservation sizing unaffected by value padding, direct-streaming + multi-fragment + overflow-abort for both the produce and populate paths, proving via byte-scan that raw plaintext never appears in `logFile`).
- `KafkaCacheSegmentTest` gained a filesystem check confirming no `*.converted` file exists after `freeze()`.
- `./mvnw clean verify -pl runtime/binding-kafka`: 406 integration tests (all k3po ITs) + unit tests, 0 failures, checkstyle/license clean, JaCoCo coverage checks met — run after every stage, and again after rebasing onto latest `develop`.

Fixes #1688 

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzxN4tJLhiHQ8ikNeuN8WS)_