### PR TITLE
fix(binding-mcp): fold NamedConfig refs() generically through options.cache

### DIFF
--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpCacheConfig.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpCacheConfig.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.Config;
 
-public final class McpCacheConfig extends Config
+public final class McpCacheConfig extends Config.Extensible
 {
     public final String store;
     public final Duration ttl;
@@ -34,6 +34,7 @@ public final class McpCacheConfig extends Config
         McpAuthorizationConfig authorization,
         McpCacheToolsConfig tools)
     {
+        super(null, tools != null ? tools.refs() : null);
         this.store = store;
         this.ttl = ttl;
         this.authorization = authorization;

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpCacheToolsConfig.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpCacheToolsConfig.java
@@ -16,11 +16,14 @@ package io.aklivity.zilla.config.binding.mcp;
 
 import static java.util.function.Function.identity;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.Config;
+import io.aklivity.zilla.config.engine.NamedConfig;
 
-public final class McpCacheToolsConfig extends Config
+public final class McpCacheToolsConfig extends Config.Extensible
 {
     public final McpCacheToolsSearchConfig search;
     public final McpCacheToolsEagerConfig eager;
@@ -29,8 +32,27 @@ public final class McpCacheToolsConfig extends Config
         McpCacheToolsSearchConfig search,
         McpCacheToolsEagerConfig eager)
     {
+        super(null, withSearchAndEager(search, eager));
         this.search = search;
         this.eager = eager;
+    }
+
+    // search and eager may each contribute their own named references; folding both in here lets
+    // McpCacheConfig discover every name under tools generically via tools.refs()
+    private static List<NamedConfig> withSearchAndEager(
+        McpCacheToolsSearchConfig search,
+        McpCacheToolsEagerConfig eager)
+    {
+        List<NamedConfig> all = new ArrayList<>();
+        if (search != null)
+        {
+            all.addAll(search.refs());
+        }
+        if (eager != null)
+        {
+            all.addAll(eager.refs());
+        }
+        return all;
     }
 
     public static McpCacheToolsConfigBuilder<McpCacheToolsConfig> builder()

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpCacheToolsEagerConfig.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpCacheToolsEagerConfig.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.Config;
 
-public final class McpCacheToolsEagerConfig extends Config
+public final class McpCacheToolsEagerConfig extends Config.Extensible
 {
     public final McpCacheToolsEagerPolicy policy;
     public final List<String> match;
@@ -30,6 +30,7 @@ public final class McpCacheToolsEagerConfig extends Config
         McpCacheToolsEagerPolicy policy,
         List<String> match)
     {
+        super(null, null);
         this.policy = policy;
         this.match = match;
     }

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpCacheToolsSearchConfig.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpCacheToolsSearchConfig.java
@@ -16,13 +16,15 @@ package io.aklivity.zilla.config.binding.mcp;
 
 import static java.util.function.Function.identity;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.Config;
+import io.aklivity.zilla.config.engine.NamedConfig;
 
-public final class McpCacheToolsSearchConfig extends Config
+public final class McpCacheToolsSearchConfig extends Config.Extensible
 {
     public final String toolkit;
     public final int limit;
@@ -37,11 +39,28 @@ public final class McpCacheToolsSearchConfig extends Config
         Map<String, Double> weights,
         List<McpToolSearchIndexConfig> indexes)
     {
+        super(null, withIndexes(indexes));
         this.toolkit = toolkit;
         this.limit = limit;
         this.fields = fields;
         this.weights = weights;
         this.indexes = indexes;
+    }
+
+    // each configured index may itself contribute named references (e.g. an embedding vault); folding
+    // them in here lets McpCacheToolsConfig discover every name under search generically via search.refs()
+    private static List<NamedConfig> withIndexes(
+        List<McpToolSearchIndexConfig> indexes)
+    {
+        List<NamedConfig> all = new ArrayList<>();
+        if (indexes != null)
+        {
+            for (McpToolSearchIndexConfig index : indexes)
+            {
+                all.addAll(index.refs());
+            }
+        }
+        return all;
     }
 
     public static McpCacheToolsSearchConfigBuilder<McpCacheToolsSearchConfig> builder()

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpOptionsConfigBuilder.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpOptionsConfigBuilder.java
@@ -104,12 +104,9 @@ public final class McpOptionsConfigBuilder<T> extends ConfigBuilder<T, McpOption
         {
             refs.addAll(tools.refs());
         }
-        if (cache != null && cache.tools != null && cache.tools.search != null && cache.tools.search.indexes != null)
+        if (cache != null)
         {
-            for (McpToolSearchIndexConfig index : cache.tools.search.indexes)
-            {
-                refs.addAll(index.refs());
-            }
+            refs.addAll(cache.refs());
         }
         return mapper.apply(new McpOptionsConfig(elicitation, authorization, cache, server, tools, refs));
     }

--- a/config/binding-mcp.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/McpConfigTest.java
+++ b/config/binding-mcp.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/McpConfigTest.java
@@ -15,14 +15,136 @@
 package io.aklivity.zilla.config.binding.mcp;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.junit.Test;
 
+import io.aklivity.zilla.config.engine.NamedConfig;
+import io.aklivity.zilla.config.engine.VaultedConfig;
+
 public class McpConfigTest
 {
+    @Test
+    public void shouldForwardRefFromToolSearchIndexThroughCacheToolsSearch()
+    {
+        VaultedConfig vaulted = VaultedConfig.builder().name("vault0").build();
+
+        McpCacheToolsSearchConfig search = McpCacheToolsSearchConfig.builder()
+            .index(new McpRefTestToolSearchIndexConfig(vaulted))
+            .build();
+
+        assertThat(search.refs(), hasItem(vaulted));
+    }
+
+    @Test
+    public void shouldDefaultCacheToolsSearchRefsToEmpty()
+    {
+        McpCacheToolsSearchConfig search = McpCacheToolsSearchConfig.builder().build();
+
+        assertThat(search.refs(), empty());
+    }
+
+    @Test
+    public void shouldDefaultCacheToolsEagerRefsToEmpty()
+    {
+        McpCacheToolsEagerConfig eager = McpCacheToolsEagerConfig.builder().build();
+
+        assertThat(eager.refs(), empty());
+    }
+
+    @Test
+    public void shouldForwardRefFromCacheToolsSearchThroughCacheTools()
+    {
+        VaultedConfig vaulted = VaultedConfig.builder().name("vault0").build();
+        McpCacheToolsSearchConfig search = McpCacheToolsSearchConfig.builder()
+            .index(new McpRefTestToolSearchIndexConfig(vaulted))
+            .build();
+
+        McpCacheToolsConfig tools = McpCacheToolsConfig.builder()
+            .search(search)
+            .build();
+
+        assertThat(tools.refs(), hasItem(vaulted));
+    }
+
+    @Test
+    public void shouldDefaultCacheToolsRefsToEmpty()
+    {
+        McpCacheToolsConfig tools = McpCacheToolsConfig.builder().build();
+
+        assertThat(tools.refs(), empty());
+    }
+
+    @Test
+    public void shouldForwardRefFromCacheToolsThroughCache()
+    {
+        VaultedConfig vaulted = VaultedConfig.builder().name("vault0").build();
+        McpCacheToolsSearchConfig search = McpCacheToolsSearchConfig.builder()
+            .index(new McpRefTestToolSearchIndexConfig(vaulted))
+            .build();
+        McpCacheToolsConfig tools = McpCacheToolsConfig.builder()
+            .search(search)
+            .build();
+
+        McpCacheConfig cache = McpCacheConfig.builder()
+            .tools(tools)
+            .build();
+
+        assertThat(cache.refs(), hasItem(vaulted));
+    }
+
+    @Test
+    public void shouldDefaultCacheRefsToEmpty()
+    {
+        McpCacheConfig cache = McpCacheConfig.builder().build();
+
+        assertThat(cache.refs(), empty());
+    }
+
+    @Test
+    public void shouldForwardRefFromCacheThroughOptions()
+    {
+        VaultedConfig vaulted = VaultedConfig.builder().name("vault0").build();
+        McpCacheToolsSearchConfig search = McpCacheToolsSearchConfig.builder()
+            .index(new McpRefTestToolSearchIndexConfig(vaulted))
+            .build();
+        McpCacheToolsConfig tools = McpCacheToolsConfig.builder()
+            .search(search)
+            .build();
+        McpCacheConfig cache = McpCacheConfig.builder()
+            .tools(tools)
+            .build();
+
+        McpOptionsConfig options = (McpOptionsConfig) McpOptionsConfig.builder()
+            .cache(cache)
+            .build();
+
+        assertThat(options.refs(), hasItem(vaulted));
+    }
+
+    private static final class McpRefTestToolSearchIndexConfig extends McpToolSearchIndexConfig
+    {
+        private final List<NamedConfig> refs;
+
+        McpRefTestToolSearchIndexConfig(
+            NamedConfig ref)
+        {
+            super("test");
+            this.refs = List.of(ref);
+        }
+
+        @Override
+        public List<NamedConfig> refs()
+        {
+            return refs;
+        }
+    }
+
     @Test
     public void shouldBuildElicitationWithDefaultCallback()
     {


### PR DESCRIPTION
## Description

`McpCacheConfig`, `McpCacheToolsConfig`, and `McpCacheToolsSearchConfig` extended plain `Config`, not `Config.Extensible`, so none of them exposed a `refs()` method — the only reason any `NamedConfig` under `options.cache` resolved at all was a one-off hardcoded reach into `cache.tools.search.indexes[].refs()` inside `McpOptionsConfigBuilder`. Any `NamedConfig` nested elsewhere under `options.cache`, at any depth, was invisible to the engine's generic `NamedConfig` resolution walk (`for (NamedConfig ref : binding.options.refs()) { ref.id = resolver.resolve(ref.name); }`, #2396).

This converts `McpCacheConfig`, `McpCacheToolsConfig`, `McpCacheToolsSearchConfig`, and `McpCacheToolsEagerConfig` to `Config.Extensible`, each folding its own refs plus its children's refs in its constructor — mirroring `ModelConfig`'s existing fold-before-`super()` pattern. `McpOptionsConfigBuilder` now calls `cache.refs()` generically instead of hand-walking `cache.tools.search.indexes`.

No behavior change for existing configs — `cache.tools.search`'s named-reference resolution continues to work identically, now via the generic path instead of the hardcoded one, with regression coverage in `McpConfigTest`. This also means a `NamedConfig` nested anywhere else under `options.cache`, present or future, resolves automatically with no further `McpOptionsConfigBuilder` changes needed.

Fixes #2462

## Test plan

- [x] New unit tests (`McpConfigTest`) confirm a `NamedConfig` on a search index still resolves all the way up through `McpOptionsConfig.refs()` via the generic path, plus empty-refs defaults at each level.
- [x] Tests were written first and confirmed to fail to *compile* against the original code (no `refs()` method existed on the affected classes) before implementing the fix.
- [x] Full module `verify` passes: unit tests, checkstyle, license headers, JaCoCo coverage (70% instruction ratio threshold).
- [x] `runtime/binding-mcp` (the consumer of this config module) still compiles unchanged against the updated types.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ANpBHPguRA1Cj9HR3tbH69)_