### PR TITLE
feat(engine): resolve named vault references inside a vault's own options

### DIFF
--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/vault/config/TestVaultOptionsConfig.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/vault/config/TestVaultOptionsConfig.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.OptionsConfig;
+import io.aklivity.zilla.config.engine.VaultedConfig;
 
 public final class TestVaultOptionsConfig extends OptionsConfig
 {
@@ -25,6 +26,7 @@ public final class TestVaultOptionsConfig extends OptionsConfig
     public final TestVaultEntryConfig signer;
     public final List<TestVaultEntryConfig> trust;
     public final List<TestVaultEntryConfig> wrap;
+    public final VaultedConfig vault;
 
     public static TestVaultOptionsConfigBuilder<TestVaultOptionsConfig> builder()
     {
@@ -41,12 +43,14 @@ public final class TestVaultOptionsConfig extends OptionsConfig
         List<TestVaultEntryConfig> keys,
         TestVaultEntryConfig signer,
         List<TestVaultEntryConfig> trust,
-        List<TestVaultEntryConfig> wrap)
+        List<TestVaultEntryConfig> wrap,
+        VaultedConfig vault)
     {
-        super(null, null);
+        super(null, vault != null ? List.of(vault) : null);
         this.keys = keys;
         this.signer = signer;
         this.trust = trust;
         this.wrap = wrap;
+        this.vault = vault;
     }
 }

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/vault/config/TestVaultOptionsConfigAdapter.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/vault/config/TestVaultOptionsConfigAdapter.java
@@ -30,6 +30,7 @@ public final class TestVaultOptionsConfigAdapter extends ConfigAdapter<OptionsCo
     private static final String SIGNER_NAME = "signer";
     private static final String TRUST_NAME = "trust";
     private static final String WRAP_NAME = "wrap";
+    private static final String VAULT_NAME = "vault";
 
     private final TestVaultEntryConfigAdapter entry = new TestVaultEntryConfigAdapter();
 
@@ -86,6 +87,11 @@ public final class TestVaultOptionsConfigAdapter extends ConfigAdapter<OptionsCo
                 options.wrap.forEach(w -> wrapArray.add(entry.adaptToJson(w)));
                 object.add(WRAP_NAME, wrapArray);
             }
+        }
+
+        if (options.vault != null)
+        {
+            object.add(VAULT_NAME, options.vault.name);
         }
 
         return object.build();
@@ -161,6 +167,11 @@ public final class TestVaultOptionsConfigAdapter extends ConfigAdapter<OptionsCo
                     TestVaultEntryConfig config = entry.adaptFromJson(wrapValue.asJsonObject());
                     options.wrap(config.alias, config.entry);
                 }
+            }
+
+            if (object.containsKey(VAULT_NAME))
+            {
+                options.vault(object.getString(VAULT_NAME));
             }
         }
 

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/vault/config/TestVaultOptionsConfigBuilder.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/vault/config/TestVaultOptionsConfigBuilder.java
@@ -20,6 +20,7 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.ConfigBuilder;
 import io.aklivity.zilla.config.engine.OptionsConfig;
+import io.aklivity.zilla.config.engine.VaultedConfig;
 
 public final class TestVaultOptionsConfigBuilder<T> extends ConfigBuilder<T, TestVaultOptionsConfigBuilder<T>>
 {
@@ -29,6 +30,7 @@ public final class TestVaultOptionsConfigBuilder<T> extends ConfigBuilder<T, Tes
     private TestVaultEntryConfig signer;
     private List<TestVaultEntryConfig> trust;
     private List<TestVaultEntryConfig> wrap;
+    private VaultedConfig vault;
 
     TestVaultOptionsConfigBuilder(
         Function<OptionsConfig, T> mapper)
@@ -87,9 +89,16 @@ public final class TestVaultOptionsConfigBuilder<T> extends ConfigBuilder<T, Tes
         return this;
     }
 
+    public TestVaultOptionsConfigBuilder<T> vault(
+        String name)
+    {
+        this.vault = VaultedConfig.builder().name(name).build();
+        return this;
+    }
+
     @Override
     public T build()
     {
-        return mapper.apply(new TestVaultOptionsConfig(keys, signer, trust, wrap));
+        return mapper.apply(new TestVaultOptionsConfig(keys, signer, trust, wrap, vault));
     }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
@@ -381,6 +381,14 @@ public class EngineManager
         for (VaultConfig vault : namespace.vaults)
         {
             vault.id = resolver.resolve(vault.name);
+
+            if (vault.options != null)
+            {
+                for (NamedConfig ref : vault.options.refs())
+                {
+                    ref.id = resolver.resolve(ref.name);
+                }
+            }
         }
 
         for (CatalogConfig catalog : namespace.catalogs)

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineIT.java
@@ -241,4 +241,14 @@ public class EngineIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("server.vault.options.delegate.yaml")
+    @Specification({
+        "${net}/vault.options.delegate/client",
+        "${app}/vault.options.delegate/server"})
+    public void shouldResolveVaultReferencedByAnotherVaultsOptions() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/TestVaultContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/TestVaultContext.java
@@ -21,16 +21,19 @@ import io.aklivity.zilla.runtime.engine.vault.VaultContext;
 
 public final class TestVaultContext implements VaultContext
 {
+    private final EngineContext context;
+
     public TestVaultContext(
         EngineContext context)
     {
+        this.context = context;
     }
 
     @Override
     public TestVaultHandler attach(
         VaultConfig vault)
     {
-        return new TestVaultHandler(vault);
+        return new TestVaultHandler(vault, context);
     }
 
     @Override

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/TestVaultHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/TestVaultHandler.java
@@ -49,10 +49,12 @@ import javax.net.ssl.TrustManagerFactory;
 import org.agrona.LangUtil;
 
 import io.aklivity.zilla.config.engine.VaultConfig;
+import io.aklivity.zilla.config.engine.VaultedConfig;
 import io.aklivity.zilla.config.engine.test.internal.vault.config.TestVaultEntryConfig;
 import io.aklivity.zilla.config.engine.test.internal.vault.config.TestVaultOptionsConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.vault.SecretKeyManager;
 import io.aklivity.zilla.runtime.engine.vault.SecretKeyManagerFactory;
 import io.aklivity.zilla.runtime.engine.vault.VaultHandler;
@@ -78,15 +80,36 @@ public final class TestVaultHandler implements VaultHandler
     private final TestVaultEntryConfig signer;
     private final List<TestVaultEntryConfig> trust;
     private final Map<String, SecretKey> wraps;
+    private final VaultHandler delegate;
 
     public TestVaultHandler(
         VaultConfig vault)
+    {
+        this(vault, null);
+    }
+
+    // when options.vault names another vault in the same namespace, the engine resolves it to
+    // options.vault.id before attach (see EngineManager); any key/trust/wrap alias this handler
+    // cannot itself satisfy falls through to that referenced vault, so a vault with no material of
+    // its own can still front one that does
+    public TestVaultHandler(
+        VaultConfig vault,
+        EngineContext context)
     {
         TestVaultOptionsConfig options = (TestVaultOptionsConfig) vault.options;
         this.keys = options != null ? options.keys : null;
         this.signer = options != null ? options.signer : null;
         this.trust = options != null ? options.trust : null;
         this.wraps = options != null ? newWraps(options.wrap) : null;
+        this.delegate = delegate(options, context);
+    }
+
+    private static VaultHandler delegate(
+        TestVaultOptionsConfig options,
+        EngineContext context)
+    {
+        VaultedConfig ref = options != null ? options.vault : null;
+        return ref != null && context != null ? context.supplyVault(ref.id) : null;
     }
 
     private static Map<String, SecretKey> newWraps(
@@ -221,7 +244,11 @@ public final class TestVaultHandler implements VaultHandler
 
         List<TestVaultEntryConfig> matched = matchedKeys(aliases);
 
-        if (!matched.isEmpty())
+        if (matched.isEmpty())
+        {
+            factory = delegate != null ? delegate.initKeys(aliases) : null;
+        }
+        else
         {
             try
             {
@@ -347,7 +374,11 @@ public final class TestVaultHandler implements VaultHandler
 
         List<TestVaultEntryConfig> matched = matchedTrust(certAliases);
 
-        if (!matched.isEmpty() || cacerts != null)
+        if (matched.isEmpty() && cacerts == null)
+        {
+            factory = delegate != null ? delegate.initTrust(certAliases, cacerts) : null;
+        }
+        else
         {
             try
             {
@@ -416,7 +447,9 @@ public final class TestVaultHandler implements VaultHandler
     {
         Map<String, SecretKey> matched = matchedWraps(aliases);
         SecretKeyManager manager = !matched.isEmpty() ? new TestSecretKeyManager(matched) : null;
-        return manager != null ? () -> manager : null;
+        return manager != null
+            ? () -> manager
+            : delegate != null ? delegate.initSecretKeys(aliases) : null;
     }
 
     private Map<String, SecretKey> matchedWraps(

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.vault.options.delegate.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.vault.options.delegate.yaml
@@ -53,5 +53,6 @@ bindings:
         vault: vaultB
         exit: app1
         options:
-            vault:
-                trust: cert0
+            assertions:
+                vault:
+                    trust: cert0

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.vault.options.delegate.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.vault.options.delegate.yaml
@@ -1,0 +1,57 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: test
+vaults:
+    vaultA:
+        type: test
+        options:
+            trust:
+                alias: cert0
+                entry: |
+                    -----BEGIN CERTIFICATE-----
+                    MIIDKTCCAhGgAwIBAgIUf7Bc/rhG6QMDfvhU0eOSmWXCCLMwDQYJKoZIhvcNAQEL
+                    BQAwJDEiMCAGA1UEAwwZemlsbGEtdGVzdC12YXVsdC1kZWxlZ2F0ZTAeFw0yNjA5
+                    MDEyMjQ0MTFaFw0zNjA4MjkyMjQ0MTFaMCQxIjAgBgNVBAMMGXppbGxhLXRlc3Qt
+                    dmF1bHQtZGVsZWdhdGUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDk
+                    Afd2gxwcAS9rpIyIlRQxNEQ2IGYTD9YUij77nUj1Z7LRqALKSaRHAGn+DzjOV5kZ
+                    5+3606Sx5DB3gsGCyEvPiZCagfocu8vk6DWRcAuBaTwTubcHiJVNs/5Zwcnafqz+
+                    YZoSyJ8f56+eLuH0GjNqmqa8NLDWmKNQXoEDGVC8cTojRwtc6BvVQHaQQ/83E6ta
+                    lANxQIlZy//+UDFPnFspmnk91IJS63DWWddWs4yPfOhUeKYs96iOC9Sn9dDuPe4t
+                    sGcdGtt/cTSeMrIrnp6Ti9KeXYN9tGsE96XUU1jDbe9NSD9LHjdYZxrQQkVh/p5S
+                    KI1p/L8EDjkBz5VpwT9XAgMBAAGjUzBRMB0GA1UdDgQWBBRhI2myjzMnYZ4g1Ert
+                    /XmehaMgODAfBgNVHSMEGDAWgBRhI2myjzMnYZ4g1Ert/XmehaMgODAPBgNVHRMB
+                    Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBVk4/lkcj0pD8B9iRs1aEeKSqp
+                    ba9Tzk50x3hPDANO1mZUxXza2arYTz+VwzmBZ19cCiPigInizDv1Puv/n217CLJ9
+                    +FXgG2EW9X0jq0jF3UjNfHGB9OtR+Tgu/FrcpsESwEjjKsIq/ntWNWYBfXn4OLzu
+                    Vlvde8qInQs5MDL72ZTvf3JPRLGoQk9IoO1sCtPHqQkkY8WGbsx/bmFT4NSbl+Bn
+                    AKctnsj0ts6JaoRz/Yl3zGwjKK18xbU0ahqpzkH+EMP69D13k3F3WUTGRj/EdZ7U
+                    KJwdVS3israPX8TTT4Qhtv2CKfmza5sAeIChwbglOoY9bNnel3RAYhkThop/
+                    -----END CERTIFICATE-----
+    vaultB:
+        type: test
+        options:
+            vault: vaultA
+bindings:
+    net1:
+        type: test
+        kind: server
+        vault: vaultB
+        exit: app1
+        options:
+            vault:
+                trust: cert0

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/vault/test.schema.patch.json
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/vault/test.schema.patch.json
@@ -195,6 +195,11 @@
                                         }
                                     }
                                 ]
+                            },
+                            "vault":
+                            {
+                                "title": "Referenced vault",
+                                "type": "string"
                             }
                         }
                     }

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/vault.options.delegate/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/vault.options.delegate/server.rpt
@@ -1,0 +1,22 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app1"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+
+accepted
+connected

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/vault.options.delegate/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/vault.options.delegate/client.rpt
@@ -1,0 +1,20 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net1"
+        option zilla:transmission "duplex"
+        option zilla:window 8192
+connected


### PR DESCRIPTION
## Description

A binding's `options` can already name another engine resource (e.g. a vault) and have the engine resolve that name to an id before attach — `EngineManager` walks `binding.options.refs()` (a list of `NamedConfig` entries) once per namespace and fills in each `ref.id`. A vault's own `options` had no equivalent: `EngineManager` resolved a vault's own `name` to `id`, but never walked `vault.options.refs()`, so a vault whose own options need to reference another named vault in the same namespace had no way to get that reference resolved to an id.

This extends the existing per-namespace vault loop to also resolve `vault.options.refs()`, mirroring the `binding.options.refs()` walk exactly — no new engine SPI surface, just closing a gap in behavior that already exists for bindings.

To prove the fix end-to-end without any new production module, this also extends the engine's own `TestVault` test implementation (used only by `specs/engine.spec`'s `EngineIT`) with an optional `vault: <name>` option, backed by the existing `VaultedConfig`/`NamedConfig` type built for exactly this purpose. `TestVaultHandler` falls back to the referenced vault's `initKeys`/`initTrust`/`initSecretKeys` when it has no matching material of its own, and a new `EngineIT` scenario (`server.vault.options.delegate.yaml`) configures one `type: test` vault fronting another and verifies the reference resolves and the fronted vault's material is used.

### Testing

- `./mvnw verify -pl config/engine.conf` — unit tests, including the pre-existing `TestVaultHandlerTest` (unaffected, since the new `EngineContext` constructor parameter is additive)
- `./mvnw verify -pl runtime/engine` — unit + integration tests, including the new `EngineIT#shouldResolveVaultReferencedByAnotherVaultsOptions`
- `./mvnw verify -pl specs/engine.spec` — schema validation and spec-level tests

Fixes # (N/A — no tracking issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_013yHEVwq9N53Pwsd1NwueAG)_