### PR TITLE
model pipelines: categorize rejections as parse, validation, or transform failures

### DIFF
--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroDiagnostic.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroDiagnostic.java
@@ -23,8 +23,8 @@ package io.aklivity.zilla.runtime.common.avro;
  * {@link AvroReporter#rejected(AvroDiagnostic)} callback. A reporter that needs to retain any of it must
  * copy the value out immediately, before returning.
  * <p>
- * Starts with {@link #message()}; structured accessors (byte offset, field, category) may be added without
- * changing the pipeline's {@code Status} contract.
+ * Starts with {@link #message()}; structured accessors (byte offset, field) may be added without changing
+ * the pipeline's {@code Status} contract.
  */
 public interface AvroDiagnostic
 {
@@ -34,4 +34,36 @@ public interface AvroDiagnostic
      * component supplied no message.
      */
     String message();
+
+    /**
+     * The category of failure this rejection stems from.
+     */
+    Category category();
+
+    /**
+     * Distinguishes a genuinely invalid or malformed value from any other rejection reason, so a reporter
+     * need not assume every rejection is a validation failure.
+     */
+    enum Category
+    {
+        /**
+         * No valid value could be produced at all — whether because the bytes are malformed (e.g. a
+         * truncated variable-length integer or negative block count) or because they are structurally
+         * non-conformant to the schema (e.g. a wrong scalar type, an unexpected field key, an out-of-range
+         * union branch or enum ordinal, or a {@code fixed} of the wrong size). See {@link AvroParsingException}.
+         */
+        PARSING,
+
+        /**
+         * A structurally-valid value that violates a semantic rule beyond the schema's structure — e.g. a
+         * logical-type constraint or a data contract. See {@link AvroValidationException}.
+         */
+        VALIDATION,
+
+        /**
+         * The rejection stems from some other cause — e.g. an exception thrown by an extension's own
+         * transform logic — rather than the value itself being invalid.
+         */
+        TRANSFORM
+    }
 }

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
@@ -94,6 +94,7 @@ final class AvroPipelineImpl implements AvroPipeline
         suspended = false;
         completed = false;
         diagnostic.message = null;
+        diagnostic.category = null;
     }
 
     @Override
@@ -163,6 +164,7 @@ final class AvroPipelineImpl implements AvroPipeline
         {
             // inert today — no stage throws this yet; wired for when semantic validation lands
             diagnostic.message = ex.getMessage();
+            diagnostic.category = AvroDiagnostic.Category.VALIDATION;
             reporter.rejected(diagnostic);
             status = lenient ? COMPLETED : REJECTED;
         }
@@ -170,11 +172,13 @@ final class AvroPipelineImpl implements AvroPipeline
         {
             status = REJECTED;
             diagnostic.message = ex.getMessage();
+            diagnostic.category = AvroDiagnostic.Category.PARSING;
         }
         catch (AvroException ex)
         {
             status = REJECTED;
             diagnostic.message = ex.getMessage();
+            diagnostic.category = AvroDiagnostic.Category.TRANSFORM;
         }
         if (status == REJECTED)
         {
@@ -363,11 +367,18 @@ final class AvroPipelineImpl implements AvroPipeline
     private static final class Diagnostic implements AvroDiagnostic
     {
         private String message;
+        private Category category;
 
         @Override
         public String message()
         {
             return message;
+        }
+
+        @Override
+        public Category category()
+        {
+            return category;
         }
     }
 }

--- a/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineRejectTest.java
+++ b/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineRejectTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.avro.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.avro.Avro;
+import io.aklivity.zilla.runtime.common.avro.AvroController;
+import io.aklivity.zilla.runtime.common.avro.AvroDiagnostic.Category;
+import io.aklivity.zilla.runtime.common.avro.AvroEvent;
+import io.aklivity.zilla.runtime.common.avro.AvroException;
+import io.aklivity.zilla.runtime.common.avro.AvroGenerator;
+import io.aklivity.zilla.runtime.common.avro.AvroPipeline;
+import io.aklivity.zilla.runtime.common.avro.AvroPipeline.Status;
+import io.aklivity.zilla.runtime.common.avro.AvroReporter;
+import io.aklivity.zilla.runtime.common.avro.AvroSchema;
+import io.aklivity.zilla.runtime.common.avro.AvroSink;
+import io.aklivity.zilla.runtime.common.avro.AvroSource;
+import io.aklivity.zilla.runtime.common.avro.AvroTransform;
+import io.aklivity.zilla.runtime.common.avro.AvroValidationException;
+
+class AvroPipelineRejectTest
+{
+    // captures the call-scoped diagnostic the pipeline pushes on a terminal REJECTED, copying it out
+    private final String[] reason = new String[1];
+    private final Category[] category = new Category[1];
+    private final AvroReporter reporter = d ->
+    {
+        reason[0] = d.message();
+        category[0] = d.category();
+    };
+
+    // An unterminated variable-length integer (continuation bit set, no terminating byte) is malformed
+    // binary the parser cannot decode at all -- a parse failure, not a schema violation.
+    @Test
+    void shouldReportParsingFailure()
+    {
+        AvroSchema schema = Avro.schema("\"int\"");
+        AvroPipeline pipeline = Avro.stream(Avro.parser(schema))
+            .reporting(reporter)
+            .into(generatorFor(schema));
+        pipeline.reset();
+
+        byte[] in = { (byte) 0xFF };
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[128]);
+        AvroPipeline.Status status = pipeline.transform(srcOf(in), 0, in.length, true, dst, 0, dst.capacity()).status();
+
+        assertEquals(Status.REJECTED, status);
+        assertNotNull(reason[0]);
+        assertEquals(Category.PARSING, category[0]);
+    }
+
+    // A stage's own AvroException (not a parsing nor a validation exception) stands in for an extension's
+    // internal failure during its own transform logic -- distinct from the value itself being invalid.
+    @Test
+    void shouldReportTransformFailure()
+    {
+        AvroSchema schema = Avro.schema("\"string\"");
+        AvroPipeline pipeline = Avro.stream(Avro.parser(schema))
+            .transform(failingWith(new AvroException("extension failure")))
+            .reporting(reporter)
+            .into(generatorFor(schema));
+        pipeline.reset();
+
+        // "foo": length 3 (zigzag varint 0x06) followed by the three bytes
+        byte[] in = { 0x06, 0x66, 0x6f, 0x6f };
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[128]);
+        AvroPipeline.Status status = pipeline.transform(srcOf(in), 0, in.length, true, dst, 0, dst.capacity()).status();
+
+        assertEquals(Status.REJECTED, status);
+        assertEquals("extension failure", reason[0]);
+        assertEquals(Category.TRANSFORM, category[0]);
+    }
+
+    // AvroValidationException has no built-in stage that throws it yet (reserved for semantic validation
+    // beyond structure), but the pipeline still categorizes it correctly wherever a stage does throw one.
+    @Test
+    void shouldReportValidationFailure()
+    {
+        AvroSchema schema = Avro.schema("\"string\"");
+        AvroPipeline pipeline = Avro.stream(Avro.parser(schema))
+            .transform(failingWith(new AvroValidationException("semantic violation")))
+            .reporting(reporter)
+            .into(generatorFor(schema));
+        pipeline.reset();
+
+        byte[] in = { 0x06, 0x66, 0x6f, 0x6f };
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[128]);
+        AvroPipeline.Status status = pipeline.transform(srcOf(in), 0, in.length, true, dst, 0, dst.capacity()).status();
+
+        assertEquals(Status.REJECTED, status);
+        assertEquals("semantic violation", reason[0]);
+        assertEquals(Category.VALIDATION, category[0]);
+    }
+
+    @Test
+    void shouldNotReportOnValidAvro()
+    {
+        AvroSchema schema = Avro.schema("\"string\"");
+        AvroPipeline pipeline = Avro.stream(Avro.parser(schema))
+            .reporting(reporter)
+            .into(generatorFor(schema));
+        pipeline.reset();
+
+        byte[] in = { 0x06, 0x66, 0x6f, 0x6f };
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[128]);
+        AvroPipeline.Status status = pipeline.transform(srcOf(in), 0, in.length, true, dst, 0, dst.capacity()).status();
+
+        assertEquals(Status.COMPLETED, status);
+        assertNull(reason[0]);
+        assertNull(category[0]);
+    }
+
+    private static AvroGenerator generatorFor(
+        AvroSchema schema)
+    {
+        return Avro.generator(schema, new UnsafeBufferEx(new byte[1]), 0);
+    }
+
+    private static MutableDirectBufferEx srcOf(
+        byte[] bytes)
+    {
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[bytes.length]);
+        buffer.putBytes(0, bytes);
+        return buffer;
+    }
+
+    private static AvroTransform failingWith(
+        RuntimeException failure)
+    {
+        return new AvroTransform()
+        {
+            @Override
+            public AvroPipeline.Status transform(
+                AvroController control,
+                AvroSource source,
+                AvroEvent event,
+                AvroSink sink)
+            {
+                throw failure;
+            }
+        };
+    }
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonDiagnostic.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonDiagnostic.java
@@ -22,8 +22,8 @@ package io.aklivity.zilla.runtime.common.json;
  * {@link JsonReporter#rejected(JsonDiagnostic)} callback. A reporter that needs to retain any of it must
  * copy the value out immediately, before returning.
  * <p>
- * Starts with {@link #message()}; structured accessors (byte offset, JSON pointer, category) may be added
- * without changing the pipeline's {@code Status} contract.
+ * Starts with {@link #message()}; structured accessors (byte offset, JSON pointer) may be added without
+ * changing the pipeline's {@code Status} contract.
  */
 public interface JsonDiagnostic
 {
@@ -32,4 +32,32 @@ public interface JsonDiagnostic
      * violation, or truncated input — or {@code null} when the rejecting component supplied no message.
      */
     String message();
+
+    /**
+     * The category of failure this rejection stems from.
+     */
+    Category category();
+
+    /**
+     * Distinguishes a genuinely invalid or malformed value from any other rejection reason, so a reporter
+     * need not assume every rejection is a validation failure.
+     */
+    enum Category
+    {
+        /**
+         * The value's syntax could not be parsed at all — e.g. malformed JSON.
+         */
+        PARSING,
+
+        /**
+         * The value parsed but does not conform to its schema — a schema-constraint violation.
+         */
+        VALIDATION,
+
+        /**
+         * The rejection stems from some other cause — e.g. an exception thrown by an extension's own
+         * transform logic — rather than the value itself being invalid.
+         */
+        TRANSFORM
+    }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -89,6 +89,7 @@ public final class JsonPipelineImpl implements JsonPipeline
         suspended = false;
         completed = false;
         diagnostic.message = null;
+        diagnostic.category = null;
         resumeEvent = null;
     }
 
@@ -193,6 +194,7 @@ public final class JsonPipelineImpl implements JsonPipeline
         catch (JsonValidationException ex)
         {
             diagnostic.message = ex.getMessage();
+            diagnostic.category = JsonDiagnostic.Category.VALIDATION;
             reporter.rejected(diagnostic);
             status = lenient ? Status.COMPLETED : Status.REJECTED;
         }
@@ -200,11 +202,13 @@ public final class JsonPipelineImpl implements JsonPipeline
         {
             status = Status.REJECTED;
             diagnostic.message = ex.getMessage();
+            diagnostic.category = JsonDiagnostic.Category.PARSING;
         }
         catch (JsonException ex)
         {
             status = Status.REJECTED;
             diagnostic.message = ex.getMessage();
+            diagnostic.category = JsonDiagnostic.Category.TRANSFORM;
         }
         if (status == Status.REJECTED)
         {
@@ -396,11 +400,18 @@ public final class JsonPipelineImpl implements JsonPipeline
     private static final class Diagnostic implements JsonDiagnostic
     {
         private String message;
+        private Category category;
 
         @Override
         public String message()
         {
             return message;
+        }
+
+        @Override
+        public Category category()
+        {
+            return category;
         }
     }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineRejectTest.java
@@ -19,22 +19,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import jakarta.json.JsonException;
+
 import org.junit.jupiter.api.Test;
 
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonDiagnostic.Category;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 import io.aklivity.zilla.runtime.common.json.JsonReporter;
 import io.aklivity.zilla.runtime.common.json.JsonSchema;
+import io.aklivity.zilla.runtime.common.json.JsonTransform;
 
 class JsonPipelineRejectTest
 {
     // captures the call-scoped diagnostic the pipeline pushes on a terminal REJECTED, copying the message out
     private final String[] reason = new String[1];
-    private final JsonReporter reporter = d -> reason[0] = d.message();
+    private final Category[] category = new Category[1];
+    private final JsonReporter reporter = d ->
+    {
+        reason[0] = d.message();
+        category[0] = d.category();
+    };
 
     // Malformed JSON is a rejection of the value, surfaced as the terminal REJECTED status rather than
     // an exception escaping feed() — mirroring how the protobuf pipeline maps a decode failure.
@@ -69,6 +78,7 @@ class JsonPipelineRejectTest
 
         assertEquals(Status.REJECTED, pipeline.transform(new UnsafeBufferEx(bytes), 0, bytes.length));
         assertNotNull(reason[0]);
+        assertEquals(Category.PARSING, category[0]);
     }
 
     // A schema violation is well-formed JSON the validator rejects; the validator throws a descriptive
@@ -91,6 +101,7 @@ class JsonPipelineRejectTest
 
         assertEquals(Status.REJECTED, pipeline.transform(new UnsafeBufferEx(bytes), 0, bytes.length));
         assertEquals("[1,11][/id] expected string but was number", reason[0]);
+        assertEquals(Category.VALIDATION, category[0]);
     }
 
     @Test
@@ -110,6 +121,32 @@ class JsonPipelineRejectTest
 
         assertEquals(Status.REJECTED, pipeline.transform(new UnsafeBufferEx(bytes), 0, bytes.length));
         assertEquals("[2,12][/id] expected string but was number", reason[0]);
+        assertEquals(Category.VALIDATION, category[0]);
+    }
+
+    // A stage's own exception (not a JsonParsingException nor a JsonValidationException) is any extension's
+    // internal failure — distinct from the value itself being invalid — and lands in the generic catch-all.
+    @Test
+    void shouldReportTransformFailure()
+    {
+        JsonTransform failing = (control, source, event, sink) ->
+        {
+            throw new JsonException("extension failure");
+        };
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBufferEx output = new UnsafeBufferEx(new byte[128]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(failing)
+            .reporting(reporter)
+            .into(JsonEx.createSink(generator));
+
+        byte[] bytes = "[1,2]".getBytes(UTF_8);
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        assertEquals(Status.REJECTED, pipeline.transform(new UnsafeBufferEx(bytes), 0, bytes.length));
+        assertEquals("extension failure", reason[0]);
+        assertEquals(Category.TRANSFORM, category[0]);
     }
 
     @Test
@@ -127,5 +164,6 @@ class JsonPipelineRejectTest
 
         assertEquals(Status.COMPLETED, pipeline.transform(new UnsafeBufferEx(bytes), 0, bytes.length));
         assertNull(reason[0]);
+        assertNull(category[0]);
     }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufDiagnostic.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufDiagnostic.java
@@ -23,8 +23,8 @@ package io.aklivity.zilla.runtime.common.protobuf;
  * {@link ProtobufReporter#rejected(ProtobufDiagnostic)} callback. A reporter that needs to retain any of
  * it must copy the value out immediately, before returning.
  * <p>
- * Starts with {@link #message()}; structured accessors (byte offset, field number, category) may be added
- * without changing the pipeline's {@code Status} contract.
+ * Starts with {@link #message()}; structured accessors (byte offset, field number) may be added without
+ * changing the pipeline's {@code Status} contract.
  */
 public interface ProtobufDiagnostic
 {
@@ -34,4 +34,37 @@ public interface ProtobufDiagnostic
      * no message.
      */
     String message();
+
+    /**
+     * The category of failure this rejection stems from.
+     */
+    Category category();
+
+    /**
+     * Distinguishes a genuinely invalid or malformed value from any other rejection reason, so a reporter
+     * need not assume every rejection is a validation failure.
+     */
+    enum Category
+    {
+        /**
+         * No valid value could be produced at all — whether because the bytes are malformed on the wire,
+         * or because they are structurally non-conformant to the descriptor (e.g. an unknown message, an
+         * unknown field, an unknown enum value, or an unsupported scalar type). See
+         * {@link ProtobufParsingException}.
+         */
+        PARSING,
+
+        /**
+         * A structurally-valid value that violates a semantic rule beyond the descriptor's structure — e.g.
+         * a data contract or a constraint not expressible in the descriptor itself. See
+         * {@link ProtobufValidationException}.
+         */
+        VALIDATION,
+
+        /**
+         * The rejection stems from some other cause — e.g. an exception thrown by an extension's own
+         * transform logic — rather than the value itself being invalid.
+         */
+        TRANSFORM
+    }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufValidationException.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufValidationException.java
@@ -15,12 +15,12 @@
 package io.aklivity.zilla.runtime.common.protobuf;
 
 /**
- * Reserved for a structurally-valid value that violates a semantic rule beyond the descriptor's structure —
- * for example a data contract or a constraint not expressible in the descriptor itself. A failure to produce
- * a valid value at all — malformed bytes or structural descriptor non-conformance — is a
- * {@link ProtobufParsingException} instead; both share the {@link ProtobufException} base so a pipeline
- * rejects either with a single catch. Currently unused: there is no semantic-validation stage yet, so
- * nothing throws this; it is the seam where data-contract enforcement will live.
+ * Thrown by the descriptor-level semantic validation stage — currently, proto2 {@code required}-field
+ * presence per message scope — for a value the core parser already decoded structurally but that violates
+ * a rule beyond the wire-level descriptor structure. A failure to produce a valid value at all — malformed
+ * bytes or a wire-type/declared-type mismatch — is a {@link ProtobufParsingException} instead; both share
+ * the {@link ProtobufException} base so a pipeline rejects either with a single catch. This is also the
+ * seam where broader data-contract enforcement will live.
  */
 public class ProtobufValidationException extends ProtobufException
 {

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufParserImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufParserImpl.java
@@ -20,11 +20,11 @@ import java.util.List;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufEvent;
-import io.aklivity.zilla.runtime.common.protobuf.ProtobufException;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufField;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufLocation;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufParser;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufParsingException;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSource;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufType;
@@ -347,7 +347,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
             }
             else if (len < 0)
             {
-                throw new ProtobufException("negative length " + len);
+                throw new ProtobufParsingException("negative length " + len);
             }
             else if (len <= reader.available())
             {
@@ -364,7 +364,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
             }
             else if (reader.last())
             {
-                throw new ProtobufException("truncated field: need " + len + " bytes");
+                throw new ProtobufParsingException("truncated field: need " + len + " bytes");
             }
             else
             {
@@ -445,7 +445,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
         ProtobufMessage root = schema != null ? schema.message(messageName) : null;
         if (schema != null && root == null)
         {
-            throw new ProtobufException("unknown message " + messageName);
+            throw new ProtobufParsingException("unknown message " + messageName);
         }
         depth = 0;
         Frame frame = frame(0);
@@ -477,7 +477,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
                 }
                 else if (reader.last())
                 {
-                    throw new ProtobufException("truncated field");
+                    throw new ProtobufParsingException("truncated field");
                 }
                 else
                 {
@@ -514,7 +514,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
                 }
                 else
                 {
-                    throw new ProtobufException(frame.group
+                    throw new ProtobufParsingException(frame.group
                         ? "unterminated group " + frame.groupNumber
                         : "truncated message");
                 }
@@ -551,7 +551,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
             {
                 if (!frame.group || number != frame.groupNumber)
                 {
-                    throw new ProtobufException("unexpected group end " + number);
+                    throw new ProtobufParsingException("unexpected group end " + number);
                 }
                 event = endFrame();
             }
@@ -589,7 +589,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
             {
                 if (len < 0)
                 {
-                    throw new ProtobufException("negative length " + len);
+                    throw new ProtobufParsingException("negative length " + len);
                 }
                 skipRemaining = len;
             }
@@ -640,7 +640,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
         {
             if (wt != ProtobufWireType.SGROUP)
             {
-                throw new ProtobufException("field " + number + " expected group");
+                throw new ProtobufParsingException("field " + number + " expected group");
             }
             regionOffset = reader.offset();
             regionLength = -1;
@@ -649,7 +649,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
         {
             if (wt != ProtobufWireType.LEN)
             {
-                throw new ProtobufException("field " + number + " expected length-delimited message");
+                throw new ProtobufParsingException("field " + number + " expected length-delimited message");
             }
             regionLength = reader.readLength();
             regionOffset = reader.offset();
@@ -684,12 +684,12 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
             depth++;
             if (depth >= MAX_DEPTH)
             {
-                throw new ProtobufException("message nesting exceeds " + MAX_DEPTH);
+                throw new ProtobufParsingException("message nesting exceeds " + MAX_DEPTH);
             }
             ProtobufMessage nested = compositeField.message();
             if (nested == null)
             {
-                throw new ProtobufException("unresolved message type " + compositeField.typeName());
+                throw new ProtobufParsingException("unresolved message type " + compositeField.typeName());
             }
             boolean group = compositeField.type() == ProtobufType.GROUP;
             phase = PHASE_NONE;
@@ -720,7 +720,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
         if (reader.starved())
         {
             // M1: a composite segment must be fully buffered; streaming segments arrive in M2
-            throw new ProtobufException("segment exceeds available window");
+            throw new ProtobufParsingException("segment exceeds available window");
         }
         phase = PHASE_NONE;
         field = compositeField;
@@ -788,7 +788,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
             floatValue = Float.intBitsToFloat(reader.readFixed32());
             break;
         default:
-            throw new ProtobufException("unsupported scalar type " + field.type());
+            throw new ProtobufParsingException("unsupported scalar type " + field.type());
         }
     }
 
@@ -819,7 +819,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
             slice(reader.buffer(), bodyStart, bodyEnd - bodyStart);
             break;
         default:
-            throw new ProtobufException("unexpected wire type " + wireType);
+            throw new ProtobufParsingException("unexpected wire type " + wireType);
         }
     }
 
@@ -830,7 +830,7 @@ public final class ProtobufParserImpl implements ProtobufParser, ProtobufSource
         boolean packed = field.repeated() && field.type().packable() && wireType == ProtobufWireType.LEN;
         if (!packed && wireType != field.type().wireType())
         {
-            throw new ProtobufException("field " + field.number() + " wire type " + wireType +
+            throw new ProtobufParsingException("field " + field.number() + " wire type " + wireType +
                 " incompatible with " + field.type());
         }
     }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineImpl.java
@@ -99,6 +99,7 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
         suspended = false;
         starved = false;
         diagnostic.message = null;
+        diagnostic.category = null;
         resumeEvent = null;
     }
 
@@ -171,6 +172,7 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
         {
             // inert today — no stage throws this yet; wired for when semantic validation lands
             diagnostic.message = ex.getMessage();
+            diagnostic.category = ProtobufDiagnostic.Category.VALIDATION;
             reporter.rejected(diagnostic);
             status = lenient ? Status.COMPLETED : Status.REJECTED;
             suspended = false;
@@ -180,11 +182,13 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
         {
             status = Status.REJECTED;
             diagnostic.message = ex.getMessage();
+            diagnostic.category = ProtobufDiagnostic.Category.PARSING;
         }
         catch (ProtobufException ex)
         {
             status = Status.REJECTED;
             diagnostic.message = ex.getMessage();
+            diagnostic.category = ProtobufDiagnostic.Category.TRANSFORM;
         }
         if (status == Status.REJECTED)
         {
@@ -381,11 +385,18 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
     private static final class Diagnostic implements ProtobufDiagnostic
     {
         private String message;
+        private Category category;
 
         @Override
         public String message()
         {
             return message;
+        }
+
+        @Override
+        public Category category()
+        {
+            return category;
         }
     }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufReader.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufReader.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.runtime.common.protobuf.internal;
 import java.nio.ByteOrder;
 
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
-import io.aklivity.zilla.runtime.common.protobuf.ProtobufException;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufParsingException;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufWireType;
 
 /**
@@ -26,9 +26,9 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufWireType;
  * The cursor separates two bounds: {@link #limit()} is the end of the bytes currently <em>available</em>
  * (refillable across windows), while a higher layer tracks each scope's semantic end via the swap-safe
  * {@link #position()} counter. A read that would cross {@link #limit()} resolves by the {@code last} flag:
- * when {@code last} (the whole-buffer contract) it raises a {@link ProtobufException} — truncated input is
- * rejected — otherwise it sets {@link #starved()} and returns without reading out of bounds, so the caller
- * can {@link #rewind()} to the last {@link #mark()} (a committed unit boundary) and report starvation.
+ * when {@code last} (the whole-buffer contract) it raises a {@link ProtobufParsingException} — truncated
+ * input is rejected — otherwise it sets {@link #starved()} and returns without reading out of bounds, so the
+ * caller can {@link #rewind()} to the last {@link #mark()} (a committed unit boundary) and report starvation.
  * <p>
  * The cursor never copies or retains bytes: it reads directly from the window it is given. Whatever the
  * driver has not yet consumed (everything at or after {@link #position()}) is the driver's to retain and
@@ -157,7 +157,7 @@ public final class ProtobufReader
             {
                 if (last)
                 {
-                    throw new ProtobufException("truncated varint");
+                    throw new ProtobufParsingException("truncated varint");
                 }
                 starved = true;
                 break;
@@ -173,7 +173,7 @@ public final class ProtobufReader
         }
         if (!complete && !starved)
         {
-            throw new ProtobufException("malformed varint");
+            throw new ProtobufParsingException("malformed varint");
         }
         return value;
     }
@@ -219,7 +219,7 @@ public final class ProtobufReader
         {
             if (length < 0)
             {
-                throw new ProtobufException("negative length " + length);
+                throw new ProtobufParsingException("negative length " + length);
             }
             require(length);
         }
@@ -258,7 +258,7 @@ public final class ProtobufReader
             skip(4);
             break;
         default:
-            throw new ProtobufException("cannot skip wire type " + wireType);
+            throw new ProtobufParsingException("cannot skip wire type " + wireType);
         }
     }
 
@@ -292,7 +292,7 @@ public final class ProtobufReader
             {
                 if (last)
                 {
-                    throw new ProtobufException("unterminated group " + number);
+                    throw new ProtobufParsingException("unterminated group " + number);
                 }
                 starved = true;
                 end = progress;
@@ -311,7 +311,7 @@ public final class ProtobufReader
             {
                 if (fieldNumber != number)
                 {
-                    throw new ProtobufException("mismatched group end " + fieldNumber + " for " + number);
+                    throw new ProtobufParsingException("mismatched group end " + fieldNumber + " for " + number);
                 }
                 end = tagOffset;
             }
@@ -336,7 +336,7 @@ public final class ProtobufReader
         {
             if (last)
             {
-                throw new ProtobufException("truncated field: need " + length + " bytes");
+                throw new ProtobufParsingException("truncated field: need " + length + " bytes");
             }
             starved = true;
         }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufValidatorImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufValidatorImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufController;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufEvent;
-import io.aklivity.zilla.runtime.common.protobuf.ProtobufException;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufField;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
@@ -28,15 +27,16 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSink;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSource;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufTransform;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufValidationException;
 
 /**
  * A {@link ProtobufTransform} that validates the event stream against the descriptor while forwarding
  * every event unchanged. The driver already rejects malformed wire and wire-type/declared-type
  * mismatches; this stage adds descriptor-level semantic validation — proto2 {@code required}-field
  * presence per message scope — and reports failure at the message boundary, after the events are
- * forwarded (emit-then-abort). It throws a descriptive {@link ProtobufException} at the point of detection
- * so the pipeline maps it to {@link ProtobufPipeline.Status#REJECTED} and pushes the named missing field to
- * the reporter, rather than rejecting structurally with no message.
+ * forwarded (emit-then-abort). It throws a descriptive {@link ProtobufValidationException} at the point of
+ * detection so the pipeline maps it to {@link ProtobufPipeline.Status#REJECTED} and pushes the named missing
+ * field to the reporter, rather than rejecting structurally with no message.
  */
 public final class ProtobufValidatorImpl implements ProtobufTransform
 {
@@ -85,7 +85,7 @@ public final class ProtobufValidatorImpl implements ProtobufTransform
             {
                 // the validator knows precisely which required field is missing — describe it at the point of
                 // detection so the pipeline pushes a descriptive diagnostic, not a generic structural reject
-                throw new ProtobufException(scope(depth).describe());
+                throw new ProtobufValidationException(scope(depth).describe());
             }
             depth--;
             break;

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineRejectTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineRejectTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.protobuf.Protobuf;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufController;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufDiagnostic.Category;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufEvent;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufException;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline.Status;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufReporter;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSink;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSource;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufTransform;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufValidationException;
+
+class ProtobufPipelineRejectTest
+{
+    // captures the call-scoped diagnostic the pipeline pushes on a terminal REJECTED, copying it out
+    private final String[] reason = new String[1];
+    private final Category[] category = new Category[1];
+    private final ProtobufReporter reporter = d ->
+    {
+        reason[0] = d.message();
+        category[0] = d.category();
+    };
+
+    // An unterminated variable-length integer (continuation bit set, no terminating byte) is malformed
+    // wire bytes that cannot be decoded at all -- a parse failure, not a schema violation.
+    @Test
+    void shouldReportParsingFailure()
+    {
+        ProtobufPipeline pipeline = Protobuf.stream(Protobuf.parser())
+            .reporting(reporter)
+            .into(Protobuf.generator());
+        pipeline.reset();
+
+        byte[] in = { (byte) 0xFF };
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[128]);
+        Status status = pipeline.transform(srcOf(in), 0, in.length, true, dst, 0, dst.capacity()).status();
+
+        assertEquals(Status.REJECTED, status);
+        assertNotNull(reason[0]);
+        assertEquals(Category.PARSING, category[0]);
+    }
+
+    // A stage's own ProtobufException (not a parsing nor a validation exception) stands in for an
+    // extension's internal failure during its own transform logic.
+    @Test
+    void shouldReportTransformFailure()
+    {
+        ProtobufPipeline pipeline = Protobuf.stream(Protobuf.parser())
+            .transform(failingWith(new ProtobufException("extension failure")))
+            .reporting(reporter)
+            .into(Protobuf.generator());
+        pipeline.reset();
+
+        byte[] in = { 0x08, 0x05 };
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[128]);
+        Status status = pipeline.transform(srcOf(in), 0, in.length, true, dst, 0, dst.capacity()).status();
+
+        assertEquals(Status.REJECTED, status);
+        assertEquals("extension failure", reason[0]);
+        assertEquals(Category.TRANSFORM, category[0]);
+    }
+
+    // ProtobufValidationException has no built-in stage that throws it yet (reserved for semantic
+    // validation beyond structure), but the pipeline still categorizes it correctly wherever a stage does.
+    @Test
+    void shouldReportValidationFailure()
+    {
+        ProtobufPipeline pipeline = Protobuf.stream(Protobuf.parser())
+            .transform(failingWith(new ProtobufValidationException("semantic violation")))
+            .reporting(reporter)
+            .into(Protobuf.generator());
+        pipeline.reset();
+
+        byte[] in = { 0x08, 0x05 };
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[128]);
+        Status status = pipeline.transform(srcOf(in), 0, in.length, true, dst, 0, dst.capacity()).status();
+
+        assertEquals(Status.REJECTED, status);
+        assertEquals("semantic violation", reason[0]);
+        assertEquals(Category.VALIDATION, category[0]);
+    }
+
+    @Test
+    void shouldNotReportOnValidProtobuf()
+    {
+        ProtobufPipeline pipeline = Protobuf.stream(Protobuf.parser())
+            .reporting(reporter)
+            .into(Protobuf.generator());
+        pipeline.reset();
+
+        byte[] in = { 0x08, 0x05 };
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[128]);
+        Status status = pipeline.transform(srcOf(in), 0, in.length, true, dst, 0, dst.capacity()).status();
+
+        assertEquals(Status.COMPLETED, status);
+        assertNull(reason[0]);
+        assertNull(category[0]);
+    }
+
+    private static MutableDirectBufferEx srcOf(
+        byte[] bytes)
+    {
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[bytes.length]);
+        buffer.putBytes(0, bytes);
+        return buffer;
+    }
+
+    private static ProtobufTransform failingWith(
+        RuntimeException failure)
+    {
+        return new ProtobufTransform()
+        {
+            @Override
+            public ProtobufPipeline.Status transform(
+                ProtobufController control,
+                ProtobufSource source,
+                ProtobufEvent event,
+                ProtobufSink sink)
+            {
+                throw failure;
+            }
+        };
+    }
+}

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipeline.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipeline.java
@@ -54,6 +54,7 @@ final class AvroModelDecoderPipeline implements ModelPipeline
 
     private AvroPipeline active;
     private String diagnostic;
+    private AvroDiagnostic.Category category;
     private MutableDirectBufferEx framingBuffer;
     private int framingAt;
 
@@ -114,6 +115,7 @@ final class AvroModelDecoderPipeline implements ModelPipeline
                 }
             }
             diagnostic = null;
+            category = null;
         }
 
         ModelStatus status;
@@ -137,7 +139,20 @@ final class AvroModelDecoderPipeline implements ModelPipeline
             produced = framing + avro.produced();
             if (status == ModelStatus.REJECTED)
             {
-                handler.validationFailure(traceId, bindingId, diagnostic != null ? diagnostic : AvroModel.NAME);
+                String reason = diagnostic != null ? diagnostic : AvroModel.NAME;
+                switch (category)
+                {
+                case PARSING:
+                    handler.parsingFailure(traceId, bindingId, reason);
+                    break;
+                case TRANSFORM:
+                    handler.transformFailure(traceId, bindingId, reason);
+                    break;
+                case VALIDATION:
+                default:
+                    handler.validationFailure(traceId, bindingId, reason);
+                    break;
+                }
             }
         }
         return result.set(status, consumed, produced);
@@ -172,6 +187,7 @@ final class AvroModelDecoderPipeline implements ModelPipeline
         }
         active = null;
         diagnostic = null;
+        category = null;
     }
 
     private AvroPipeline supplyPipeline(
@@ -210,6 +226,7 @@ final class AvroModelDecoderPipeline implements ModelPipeline
         AvroDiagnostic diagnostic)
     {
         this.diagnostic = diagnostic.message();
+        this.category = diagnostic.category();
     }
 
     private static ModelStatus map(

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipeline.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipeline.java
@@ -148,6 +148,10 @@ final class AvroModelDecoderPipeline implements ModelPipeline
                 case TRANSFORM:
                     handler.transformFailure(traceId, bindingId, reason);
                     break;
+                // a stage that rejects by returning Status.REJECTED directly, without throwing, never
+                // populates a category -- treat that the same as a schema-constraint violation, matching
+                // prior behavior
+                case null:
                 case VALIDATION:
                 default:
                     handler.validationFailure(traceId, bindingId, reason);

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEventContext.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEventContext.java
@@ -14,6 +14,8 @@
  */
 package io.aklivity.zilla.runtime.model.avro.internal;
 
+import static io.aklivity.zilla.runtime.model.avro.internal.types.event.AvroModelEventType.PARSING_FAILED;
+import static io.aklivity.zilla.runtime.model.avro.internal.types.event.AvroModelEventType.TRANSFORM_FAILED;
 import static io.aklivity.zilla.runtime.model.avro.internal.types.event.AvroModelEventType.VALIDATION_FAILED;
 
 import java.nio.ByteBuffer;
@@ -36,6 +38,8 @@ public class AvroModelEventContext
     private final AvroModelEventExFW.Builder avroModelEventExRW = new AvroModelEventExFW.Builder();
     private final int avroModelTypeId;
     private final int validationFailedEventId;
+    private final int parsingFailedEventId;
+    private final int transformFailedEventId;
     private final MessageConsumer eventWriter;
     private final Clock clock;
 
@@ -44,6 +48,8 @@ public class AvroModelEventContext
     {
         this.avroModelTypeId = context.supplyTypeId(AvroModel.NAME);
         this.validationFailedEventId = context.supplyEventId("model.avro.validation.failed");
+        this.parsingFailedEventId = context.supplyEventId("model.avro.parsing.failed");
+        this.transformFailedEventId = context.supplyEventId("model.avro.transform.failed");
         this.eventWriter = context.supplyEventWriter();
         this.clock = context.clock();
     }
@@ -63,6 +69,52 @@ public class AvroModelEventContext
         EventFW event = eventRW
             .wrap(eventBuffer, 0, eventBuffer.capacity())
             .id(validationFailedEventId)
+            .timestamp(clock.millis())
+            .traceId(traceId)
+            .namespacedId(bindingId)
+            .extension(extension.buffer(), extension.offset(), extension.limit())
+            .build();
+        eventWriter.accept(avroModelTypeId, event.buffer(), event.offset(), event.limit());
+    }
+
+    public void parsingFailure(
+        long traceId,
+        long bindingId,
+        String error)
+    {
+        AvroModelEventExFW extension = avroModelEventExRW
+            .wrap(extensionBuffer, 0, extensionBuffer.capacity())
+            .parsingFailed(e -> e
+                .typeId(PARSING_FAILED.value())
+                .error(error)
+            )
+            .build();
+        EventFW event = eventRW
+            .wrap(eventBuffer, 0, eventBuffer.capacity())
+            .id(parsingFailedEventId)
+            .timestamp(clock.millis())
+            .traceId(traceId)
+            .namespacedId(bindingId)
+            .extension(extension.buffer(), extension.offset(), extension.limit())
+            .build();
+        eventWriter.accept(avroModelTypeId, event.buffer(), event.offset(), event.limit());
+    }
+
+    public void transformFailure(
+        long traceId,
+        long bindingId,
+        String error)
+    {
+        AvroModelEventExFW extension = avroModelEventExRW
+            .wrap(extensionBuffer, 0, extensionBuffer.capacity())
+            .transformFailed(e -> e
+                .typeId(TRANSFORM_FAILED.value())
+                .error(error)
+            )
+            .build();
+        EventFW event = eventRW
+            .wrap(eventBuffer, 0, eventBuffer.capacity())
+            .id(transformFailedEventId)
             .timestamp(clock.millis())
             .traceId(traceId)
             .namespacedId(bindingId)

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEventFormatter.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEventFormatter.java
@@ -18,6 +18,8 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.event.EventFormatterSpi;
 import io.aklivity.zilla.runtime.model.avro.internal.types.event.AvroModelEventExFW;
+import io.aklivity.zilla.runtime.model.avro.internal.types.event.AvroModelParsingFailedExFW;
+import io.aklivity.zilla.runtime.model.avro.internal.types.event.AvroModelTransformFailedExFW;
 import io.aklivity.zilla.runtime.model.avro.internal.types.event.AvroModelValidationFailedExFW;
 import io.aklivity.zilla.runtime.model.avro.internal.types.event.EventFW;
 
@@ -25,6 +27,10 @@ public final class AvroModelEventFormatter implements EventFormatterSpi
 {
     private static final String VALIDATION_FAILED_FORMAT = "A message payload failed validation.";
     private static final String VALIDATION_FAILED_WITH_ERROR_FORMAT = VALIDATION_FAILED_FORMAT + " %s";
+    private static final String PARSING_FAILED_FORMAT = "A message payload could not be parsed.";
+    private static final String PARSING_FAILED_WITH_ERROR_FORMAT = PARSING_FAILED_FORMAT + " %s";
+    private static final String TRANSFORM_FAILED_FORMAT = "A message payload failed to transform.";
+    private static final String TRANSFORM_FAILED_WITH_ERROR_FORMAT = TRANSFORM_FAILED_FORMAT + " %s";
 
     private final EventFW eventRO = new EventFW();
     private final AvroModelEventExFW eventExRO = new AvroModelEventExFW();
@@ -48,6 +54,12 @@ public final class AvroModelEventFormatter implements EventFormatterSpi
         case VALIDATION_FAILED:
             result = formatValidationFailed(eventEx.validationFailed());
             break;
+        case PARSING_FAILED:
+            result = formatParsingFailed(eventEx.parsingFailed());
+            break;
+        case TRANSFORM_FAILED:
+            result = formatTransformFailed(eventEx.transformFailed());
+            break;
         }
         return result;
     }
@@ -59,5 +71,23 @@ public final class AvroModelEventFormatter implements EventFormatterSpi
         return error != null
             ? String.format(VALIDATION_FAILED_WITH_ERROR_FORMAT, error)
             : VALIDATION_FAILED_FORMAT;
+    }
+
+    private String formatParsingFailed(
+        AvroModelParsingFailedExFW parsingFailed)
+    {
+        String error = parsingFailed.error().asString();
+        return error != null
+            ? String.format(PARSING_FAILED_WITH_ERROR_FORMAT, error)
+            : PARSING_FAILED_FORMAT;
+    }
+
+    private String formatTransformFailed(
+        AvroModelTransformFailedExFW transformFailed)
+    {
+        String error = transformFailed.error().asString();
+        return error != null
+            ? String.format(TRANSFORM_FAILED_WITH_ERROR_FORMAT, error)
+            : TRANSFORM_FAILED_FORMAT;
     }
 }

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
@@ -287,4 +287,20 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
     {
         event.validationFailure(traceId, bindingId, diagnostic);
     }
+
+    void parsingFailure(
+        long traceId,
+        long bindingId,
+        String diagnostic)
+    {
+        event.parsingFailure(traceId, bindingId, diagnostic);
+    }
+
+    void transformFailure(
+        long traceId,
+        long bindingId,
+        String diagnostic)
+    {
+        event.transformFailure(traceId, bindingId, diagnostic);
+    }
 }

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,9 +38,18 @@ import io.aklivity.zilla.config.model.avro.AvroModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.avro.AvroController;
+import io.aklivity.zilla.runtime.common.avro.AvroEvent;
+import io.aklivity.zilla.runtime.common.avro.AvroException;
+import io.aklivity.zilla.runtime.common.avro.AvroPipeline;
 import io.aklivity.zilla.runtime.common.avro.AvroSchema;
+import io.aklivity.zilla.runtime.common.avro.AvroSink;
+import io.aklivity.zilla.runtime.common.avro.AvroSource;
+import io.aklivity.zilla.runtime.common.avro.AvroTransform;
+import io.aklivity.zilla.runtime.common.avro.AvroTransformable;
 import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.model.ModelCache;
 import io.aklivity.zilla.runtime.engine.model.ModelController;
 import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
@@ -51,8 +61,12 @@ import io.aklivity.zilla.runtime.engine.model.ModelSource;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+import io.aklivity.zilla.runtime.model.avro.ext.AvroCache;
 import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtContext;
 import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtHandler;
+import io.aklivity.zilla.runtime.model.avro.internal.types.event.AvroModelEventExFW;
+import io.aklivity.zilla.runtime.model.avro.internal.types.event.AvroModelEventType;
+import io.aklivity.zilla.runtime.model.avro.internal.types.event.EventFW;
 
 public class AvroModelDecoderPipelineTest
 {
@@ -365,6 +379,90 @@ public class AvroModelDecoderPipelineTest
 
         assertEquals(ModelStatus.COMPLETE, read.status());
         assertEquals(JSON, text(dst, read.produced()));
+    }
+
+    @Test
+    public void shouldReportParsingFailureEvent()
+    {
+        AvroModelEventType[] kind = new AvroModelEventType[1];
+        when(context.clock()).thenReturn(Clock.systemUTC());
+        when(context.supplyEventWriter()).thenReturn(capturingKind(kind));
+        AvroModelHandlerImpl handler = newHandler();
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE, ModelCache.NONE);
+
+        // an unterminated variable-length integer (continuation bit set, no terminating byte) is malformed
+        // binary the parser cannot decode at all -- a parse failure, not a schema violation
+        byte[] malformed = { (byte) 0xFF };
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(malformed), 0, malformed.length, dst, 0, dst.capacity());
+
+        assertEquals(ModelStatus.REJECTED, result.status());
+        assertEquals(AvroModelEventType.PARSING_FAILED, kind[0]);
+    }
+
+    @Test
+    public void shouldReportTransformFailureEvent()
+    {
+        AvroModelEventType[] kind = new AvroModelEventType[1];
+        when(context.clock()).thenReturn(Clock.systemUTC());
+        when(context.supplyEventWriter()).thenReturn(capturingKind(kind));
+        List<AvroModelExtContext> exts = List.of(failing());
+        AvroModelHandlerImpl handler = newHandler(SCHEMA, "json", exts);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE, ModelCache.NONE);
+
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(AVRO), 0, AVRO.length, dst, 0, dst.capacity());
+
+        assertEquals(ModelStatus.REJECTED, result.status());
+        assertEquals(AvroModelEventType.TRANSFORM_FAILED, kind[0]);
+    }
+
+    // decodes each emitted event's extension kind into the given single-element array, mirroring the
+    // production AvroModelEventFormatter's own wrap-and-switch, so a test can assert which event fired
+    // without depending on supplyEventId's (unstubbed, indistinguishable) mocked return value
+    private static MessageConsumer capturingKind(
+        AvroModelEventType[] kind)
+    {
+        EventFW eventRO = new EventFW();
+        AvroModelEventExFW extensionRO = new AvroModelEventExFW();
+        return (msgTypeId, buffer, index, length) ->
+        {
+            EventFW event = eventRO.wrap(buffer, index, index + length);
+            AvroModelEventExFW extension = extensionRO
+                .wrap(event.extension().buffer(), event.extension().offset(), event.extension().limit());
+            kind[0] = extension.kind();
+        };
+    }
+
+    // A stage's own exception (not a parsing nor a validation exception) standing in for an extension's
+    // internal failure during its own transform logic.
+    private static AvroModelExtContext failing()
+    {
+        return (schema, config) -> new AvroModelExtHandler()
+        {
+            @Override
+            public <T extends AvroTransformable<T>> T decode(
+                T transformable,
+                AvroCache cache)
+            {
+                return transformable.transform(new Failing());
+            }
+        };
+    }
+
+    private static final class Failing implements AvroTransform
+    {
+        @Override
+        public AvroPipeline.Status transform(
+            AvroController control,
+            AvroSource source,
+            AvroEvent event,
+            AvroSink sink)
+        {
+            throw new AvroException("extension failure");
+        }
     }
 
     private AvroModelHandlerImpl newHandler()

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
@@ -188,10 +188,23 @@ final class JsonModelDecoderPipeline implements ModelPipeline
     private void onRejected(
         JsonDiagnostic diagnostic)
     {
-        // fires once per parse or schema-validation failure, at the value boundary, in both STRICT and
-        // LENIENT — so the validation-failed event is always emitted even when LENIENT tolerates the value
+        // fires once per rejection, at the value boundary, in both STRICT and LENIENT — so the event is
+        // always emitted even when LENIENT tolerates the value
         this.diagnostic = diagnostic.message();
-        handler.validationFailure(traceId, bindingId, this.diagnostic != null ? this.diagnostic : JsonModel.NAME);
+        String reason = this.diagnostic != null ? this.diagnostic : JsonModel.NAME;
+        switch (diagnostic.category())
+        {
+        case PARSING:
+            handler.parsingFailure(traceId, bindingId, reason);
+            break;
+        case TRANSFORM:
+            handler.transformFailure(traceId, bindingId, reason);
+            break;
+        case VALIDATION:
+        default:
+            handler.validationFailure(traceId, bindingId, reason);
+            break;
+        }
     }
 
     private static ModelStatus map(

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
@@ -200,6 +200,9 @@ final class JsonModelDecoderPipeline implements ModelPipeline
         case TRANSFORM:
             handler.transformFailure(traceId, bindingId, reason);
             break;
+        // a stage that rejects by returning Status.REJECTED directly, without throwing, never populates a
+        // category -- treat that the same as a schema-constraint violation, matching prior behavior
+        case null:
         case VALIDATION:
         default:
             handler.validationFailure(traceId, bindingId, reason);

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEventContext.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEventContext.java
@@ -14,6 +14,8 @@
  */
 package io.aklivity.zilla.runtime.model.json.internal;
 
+import static io.aklivity.zilla.runtime.model.json.internal.types.event.JsonModelEventType.PARSING_FAILED;
+import static io.aklivity.zilla.runtime.model.json.internal.types.event.JsonModelEventType.TRANSFORM_FAILED;
 import static io.aklivity.zilla.runtime.model.json.internal.types.event.JsonModelEventType.VALIDATION_FAILED;
 
 import java.nio.ByteBuffer;
@@ -36,6 +38,8 @@ public class JsonModelEventContext
     private final JsonModelEventExFW.Builder jsonModelEventExRW = new JsonModelEventExFW.Builder();
     private final int jsonModelTypeId;
     private final int validationFailedEventId;
+    private final int parsingFailedEventId;
+    private final int transformFailedEventId;
     private final MessageConsumer eventWriter;
     private final Clock clock;
 
@@ -44,6 +48,8 @@ public class JsonModelEventContext
     {
         this.jsonModelTypeId = context.supplyTypeId(JsonModel.NAME);
         this.validationFailedEventId = context.supplyEventId("model.json.validation.failed");
+        this.parsingFailedEventId = context.supplyEventId("model.json.parsing.failed");
+        this.transformFailedEventId = context.supplyEventId("model.json.transform.failed");
         this.eventWriter = context.supplyEventWriter();
         this.clock = context.clock();
     }
@@ -63,6 +69,52 @@ public class JsonModelEventContext
         EventFW event = eventRW
             .wrap(eventBuffer, 0, eventBuffer.capacity())
             .id(validationFailedEventId)
+            .timestamp(clock.millis())
+            .traceId(traceId)
+            .namespacedId(bindingId)
+            .extension(extension.buffer(), extension.offset(), extension.limit())
+            .build();
+        eventWriter.accept(jsonModelTypeId, event.buffer(), event.offset(), event.limit());
+    }
+
+    public void parsingFailure(
+        long traceId,
+        long bindingId,
+        String error)
+    {
+        JsonModelEventExFW extension = jsonModelEventExRW
+            .wrap(extensionBuffer, 0, extensionBuffer.capacity())
+            .parsingFailed(e -> e
+                .typeId(PARSING_FAILED.value())
+                .error(error)
+            )
+            .build();
+        EventFW event = eventRW
+            .wrap(eventBuffer, 0, eventBuffer.capacity())
+            .id(parsingFailedEventId)
+            .timestamp(clock.millis())
+            .traceId(traceId)
+            .namespacedId(bindingId)
+            .extension(extension.buffer(), extension.offset(), extension.limit())
+            .build();
+        eventWriter.accept(jsonModelTypeId, event.buffer(), event.offset(), event.limit());
+    }
+
+    public void transformFailure(
+        long traceId,
+        long bindingId,
+        String error)
+    {
+        JsonModelEventExFW extension = jsonModelEventExRW
+            .wrap(extensionBuffer, 0, extensionBuffer.capacity())
+            .transformFailed(e -> e
+                .typeId(TRANSFORM_FAILED.value())
+                .error(error)
+            )
+            .build();
+        EventFW event = eventRW
+            .wrap(eventBuffer, 0, eventBuffer.capacity())
+            .id(transformFailedEventId)
             .timestamp(clock.millis())
             .traceId(traceId)
             .namespacedId(bindingId)

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEventFormatter.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEventFormatter.java
@@ -20,6 +20,8 @@ import io.aklivity.zilla.runtime.engine.event.EventFormatterSpi;
 import io.aklivity.zilla.runtime.model.json.internal.types.StringFW;
 import io.aklivity.zilla.runtime.model.json.internal.types.event.EventFW;
 import io.aklivity.zilla.runtime.model.json.internal.types.event.JsonModelEventExFW;
+import io.aklivity.zilla.runtime.model.json.internal.types.event.JsonModelParsingFailedExFW;
+import io.aklivity.zilla.runtime.model.json.internal.types.event.JsonModelTransformFailedExFW;
 import io.aklivity.zilla.runtime.model.json.internal.types.event.JsonModelValidationFailedExFW;
 
 public final class JsonModelEventFormatter implements EventFormatterSpi
@@ -47,6 +49,18 @@ public final class JsonModelEventFormatter implements EventFormatterSpi
         {
             JsonModelValidationFailedExFW ex = extension.validationFailed();
             result = String.format("A message payload failed validation. %s", asString(ex.error()));
+            break;
+        }
+        case PARSING_FAILED:
+        {
+            JsonModelParsingFailedExFW ex = extension.parsingFailed();
+            result = String.format("A message payload could not be parsed. %s", asString(ex.error()));
+            break;
+        }
+        case TRANSFORM_FAILED:
+        {
+            JsonModelTransformFailedExFW ex = extension.transformFailed();
+            result = String.format("A message payload failed to transform. %s", asString(ex.error()));
             break;
         }
         }

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandlerImpl.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandlerImpl.java
@@ -275,4 +275,20 @@ public final class JsonModelHandlerImpl extends JsonModelHandler implements Mode
     {
         event.validationFailure(traceId, bindingId, diagnostic);
     }
+
+    void parsingFailure(
+        long traceId,
+        long bindingId,
+        String diagnostic)
+    {
+        event.parsingFailure(traceId, bindingId, diagnostic);
+    }
+
+    void transformFailure(
+        long traceId,
+        long bindingId,
+        String diagnostic)
+    {
+        event.transformFailure(traceId, bindingId, diagnostic);
+    }
 }

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipelineTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipelineTest.java
@@ -27,6 +27,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.json.JsonException;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -61,6 +63,9 @@ import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler
 import io.aklivity.zilla.runtime.model.json.ext.JsonCache;
 import io.aklivity.zilla.runtime.model.json.ext.JsonModelExtContext;
 import io.aklivity.zilla.runtime.model.json.ext.JsonModelExtHandler;
+import io.aklivity.zilla.runtime.model.json.internal.types.event.EventFW;
+import io.aklivity.zilla.runtime.model.json.internal.types.event.JsonModelEventExFW;
+import io.aklivity.zilla.runtime.model.json.internal.types.event.JsonModelEventType;
 
 public class JsonModelDecoderPipelineTest
 {
@@ -314,6 +319,106 @@ public class JsonModelDecoderPipelineTest
             .padding(new UnsafeBufferEx(in), 0, in.length);
 
         assertEquals(basePadding + 64, extPadding);
+    }
+
+    @Test
+    public void shouldReportValidationFailureEvent()
+    {
+        JsonModelEventType[] kind = new JsonModelEventType[1];
+        when(context.supplyEventWriter()).thenReturn(capturingKind(kind));
+        JsonModelHandlerImpl handler = newHandler(OBJECT_SCHEMA);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE, ModelCache.NONE);
+
+        // "id" must be a string per OBJECT_SCHEMA -- a schema-constraint violation
+        byte[] in = "{\"id\":123,\"status\":\"OK\"}".getBytes(UTF_8);
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
+
+        assertEquals(ModelStatus.REJECTED, result.status());
+        assertEquals(JsonModelEventType.VALIDATION_FAILED, kind[0]);
+    }
+
+    @Test
+    public void shouldReportParsingFailureEvent()
+    {
+        JsonModelEventType[] kind = new JsonModelEventType[1];
+        when(context.supplyEventWriter()).thenReturn(capturingKind(kind));
+        JsonModelHandlerImpl handler = newHandler();
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE, ModelCache.NONE);
+
+        // missing comma between members -- malformed syntax, not a schema violation
+        byte[] in = "{\"id\":\"123\" \"status\":\"OK\"}".getBytes(UTF_8);
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
+
+        assertEquals(ModelStatus.REJECTED, result.status());
+        assertEquals(JsonModelEventType.PARSING_FAILED, kind[0]);
+    }
+
+    @Test
+    public void shouldReportTransformFailureEvent()
+    {
+        JsonModelEventType[] kind = new JsonModelEventType[1];
+        when(context.supplyEventWriter()).thenReturn(capturingKind(kind));
+        List<JsonModelExtContext> exts = List.of(failing());
+        JsonModelHandlerImpl handler = newHandler(OBJECT_SCHEMA, exts);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE, ModelCache.NONE);
+
+        byte[] in = "{\"id\":\"123\",\"status\":\"OK\"}".getBytes(UTF_8);
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
+
+        assertEquals(ModelStatus.REJECTED, result.status());
+        assertEquals(JsonModelEventType.TRANSFORM_FAILED, kind[0]);
+    }
+
+    // decodes each emitted event's extension kind into the given single-element array, mirroring the
+    // production JsonModelEventFormatter's own wrap-and-switch, so a test can assert which event fired
+    // without depending on supplyEventId's (unstubbed, indistinguishable) mocked return value
+    private static MessageConsumer capturingKind(
+        JsonModelEventType[] kind)
+    {
+        EventFW eventRO = new EventFW();
+        JsonModelEventExFW extensionRO = new JsonModelEventExFW();
+        return (msgTypeId, buffer, index, length) ->
+        {
+            EventFW event = eventRO.wrap(buffer, index, index + length);
+            JsonModelEventExFW extension = extensionRO
+                .wrap(event.extension().buffer(), event.extension().offset(), event.extension().limit());
+            kind[0] = extension.kind();
+        };
+    }
+
+    // A stage's own exception (not a schema violation nor malformed syntax) standing in for an
+    // extension's internal failure during its own transform logic.
+    private static JsonModelExtContext failing()
+    {
+        return (schema, config) -> new JsonModelExtHandler()
+        {
+            @Override
+            public <T extends JsonTransformable<T>> T decode(
+                T stream,
+                JsonCache cache)
+            {
+                return stream.transform(new Failing());
+            }
+        };
+    }
+
+    private static final class Failing implements JsonTransform
+    {
+        @Override
+        public Status transform(
+            JsonController control,
+            JsonSource source,
+            JsonEvent event,
+            JsonSink sink)
+        {
+            throw new JsonException("extension failure");
+        }
     }
 
     private static JsonModelExtContext dropping(

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
@@ -55,6 +55,7 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
 
     private ProtobufPipeline active;
     private String diagnostic;
+    private ProtobufDiagnostic.Category category;
     private MutableDirectBufferEx framingBuffer;
     private int framingAt;
 
@@ -122,6 +123,7 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
                 }
             }
             diagnostic = null;
+            category = null;
         }
 
         ModelStatus status;
@@ -149,7 +151,20 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
             }
             else if (status == ModelStatus.REJECTED)
             {
-                handler.validationFailure(traceId, bindingId, diagnostic != null ? diagnostic : ProtobufModel.NAME);
+                String reason = diagnostic != null ? diagnostic : ProtobufModel.NAME;
+                switch (category)
+                {
+                case PARSING:
+                    handler.parsingFailure(traceId, bindingId, reason);
+                    break;
+                case TRANSFORM:
+                    handler.transformFailure(traceId, bindingId, reason);
+                    break;
+                case VALIDATION:
+                default:
+                    handler.validationFailure(traceId, bindingId, reason);
+                    break;
+                }
             }
         }
         return result.set(status, consumed, produced);
@@ -184,6 +199,7 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
         }
         active = null;
         diagnostic = null;
+        category = null;
     }
 
     private void visitExtracted(
@@ -219,6 +235,7 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
         ProtobufDiagnostic diagnostic)
     {
         this.diagnostic = diagnostic.message();
+        this.category = diagnostic.category();
     }
 
     private int writeFraming(

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
@@ -160,6 +160,10 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
                 case TRANSFORM:
                     handler.transformFailure(traceId, bindingId, reason);
                     break;
+                // a stage that rejects by returning Status.REJECTED directly, without throwing, never
+                // populates a category -- treat that the same as a schema-constraint violation, matching
+                // prior behavior
+                case null:
                 case VALIDATION:
                 default:
                     handler.validationFailure(traceId, bindingId, reason);

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEventContext.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEventContext.java
@@ -14,6 +14,8 @@
  */
 package io.aklivity.zilla.runtime.model.protobuf.internal;
 
+import static io.aklivity.zilla.runtime.model.protobuf.internal.types.event.ProtobufModelEventType.PARSING_FAILED;
+import static io.aklivity.zilla.runtime.model.protobuf.internal.types.event.ProtobufModelEventType.TRANSFORM_FAILED;
 import static io.aklivity.zilla.runtime.model.protobuf.internal.types.event.ProtobufModelEventType.VALIDATION_FAILED;
 
 import java.nio.ByteBuffer;
@@ -36,6 +38,8 @@ public class ProtobufModelEventContext
     private final ProtobufModelEventExFW.Builder protobufModelEventExRW = new ProtobufModelEventExFW.Builder();
     private final int protobufModelTypeId;
     private final int validationFailedEventId;
+    private final int parsingFailedEventId;
+    private final int transformFailedEventId;
     private final MessageConsumer eventWriter;
     private final Clock clock;
 
@@ -44,6 +48,8 @@ public class ProtobufModelEventContext
     {
         this.protobufModelTypeId = context.supplyTypeId(ProtobufModel.NAME);
         this.validationFailedEventId = context.supplyEventId("model.protobuf.validation.failed");
+        this.parsingFailedEventId = context.supplyEventId("model.protobuf.parsing.failed");
+        this.transformFailedEventId = context.supplyEventId("model.protobuf.transform.failed");
         this.eventWriter = context.supplyEventWriter();
         this.clock = context.clock();
     }
@@ -63,6 +69,52 @@ public class ProtobufModelEventContext
         EventFW event = eventRW
             .wrap(eventBuffer, 0, eventBuffer.capacity())
             .id(validationFailedEventId)
+            .timestamp(clock.millis())
+            .traceId(traceId)
+            .namespacedId(bindingId)
+            .extension(extension.buffer(), extension.offset(), extension.limit())
+            .build();
+        eventWriter.accept(protobufModelTypeId, event.buffer(), event.offset(), event.limit());
+    }
+
+    public void parsingFailure(
+        long traceId,
+        long bindingId,
+        String error)
+    {
+        ProtobufModelEventExFW extension = protobufModelEventExRW
+            .wrap(extensionBuffer, 0, extensionBuffer.capacity())
+            .parsingFailed(e -> e
+                .typeId(PARSING_FAILED.value())
+                .error(error)
+            )
+            .build();
+        EventFW event = eventRW
+            .wrap(eventBuffer, 0, eventBuffer.capacity())
+            .id(parsingFailedEventId)
+            .timestamp(clock.millis())
+            .traceId(traceId)
+            .namespacedId(bindingId)
+            .extension(extension.buffer(), extension.offset(), extension.limit())
+            .build();
+        eventWriter.accept(protobufModelTypeId, event.buffer(), event.offset(), event.limit());
+    }
+
+    public void transformFailure(
+        long traceId,
+        long bindingId,
+        String error)
+    {
+        ProtobufModelEventExFW extension = protobufModelEventExRW
+            .wrap(extensionBuffer, 0, extensionBuffer.capacity())
+            .transformFailed(e -> e
+                .typeId(TRANSFORM_FAILED.value())
+                .error(error)
+            )
+            .build();
+        EventFW event = eventRW
+            .wrap(eventBuffer, 0, eventBuffer.capacity())
+            .id(transformFailedEventId)
             .timestamp(clock.millis())
             .traceId(traceId)
             .namespacedId(bindingId)

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEventFormatter.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEventFormatter.java
@@ -20,6 +20,8 @@ import io.aklivity.zilla.runtime.engine.event.EventFormatterSpi;
 import io.aklivity.zilla.runtime.model.protobuf.internal.types.StringFW;
 import io.aklivity.zilla.runtime.model.protobuf.internal.types.event.EventFW;
 import io.aklivity.zilla.runtime.model.protobuf.internal.types.event.ProtobufModelEventExFW;
+import io.aklivity.zilla.runtime.model.protobuf.internal.types.event.ProtobufModelParsingFailedExFW;
+import io.aklivity.zilla.runtime.model.protobuf.internal.types.event.ProtobufModelTransformFailedExFW;
 import io.aklivity.zilla.runtime.model.protobuf.internal.types.event.ProtobufModelValidationFailedExFW;
 
 public final class ProtobufModelEventFormatter implements EventFormatterSpi
@@ -47,6 +49,18 @@ public final class ProtobufModelEventFormatter implements EventFormatterSpi
         {
             ProtobufModelValidationFailedExFW ex = extension.validationFailed();
             result = String.format("A message payload failed validation. %s.", asString(ex.error()));
+            break;
+        }
+        case PARSING_FAILED:
+        {
+            ProtobufModelParsingFailedExFW ex = extension.parsingFailed();
+            result = String.format("A message payload could not be parsed. %s.", asString(ex.error()));
+            break;
+        }
+        case TRANSFORM_FAILED:
+        {
+            ProtobufModelTransformFailedExFW ex = extension.transformFailed();
+            result = String.format("A message payload failed to transform. %s.", asString(ex.error()));
             break;
         }
         }

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerImpl.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerImpl.java
@@ -393,4 +393,20 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
     {
         event.validationFailure(traceId, bindingId, diagnostic);
     }
+
+    void parsingFailure(
+        long traceId,
+        long bindingId,
+        String diagnostic)
+    {
+        event.parsingFailure(traceId, bindingId, diagnostic);
+    }
+
+    void transformFailure(
+        long traceId,
+        long bindingId,
+        String diagnostic)
+    {
+        event.transformFailure(traceId, bindingId, diagnostic);
+    }
 }

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipelineTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipelineTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
+import java.time.Clock;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,8 +38,17 @@ import io.aklivity.zilla.config.model.protobuf.ProtobufModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufController;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufEvent;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufException;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSink;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSource;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufTransform;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufTransformable;
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.model.ModelCache;
 import io.aklivity.zilla.runtime.engine.model.ModelController;
 import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
@@ -50,8 +60,12 @@ import io.aklivity.zilla.runtime.engine.model.ModelSource;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+import io.aklivity.zilla.runtime.model.protobuf.ext.ProtobufCache;
 import io.aklivity.zilla.runtime.model.protobuf.ext.ProtobufModelExtContext;
 import io.aklivity.zilla.runtime.model.protobuf.ext.ProtobufModelExtHandler;
+import io.aklivity.zilla.runtime.model.protobuf.internal.types.event.EventFW;
+import io.aklivity.zilla.runtime.model.protobuf.internal.types.event.ProtobufModelEventExFW;
+import io.aklivity.zilla.runtime.model.protobuf.internal.types.event.ProtobufModelEventType;
 
 public class ProtobufModelDecoderPipelineTest
 {
@@ -397,6 +411,90 @@ public class ProtobufModelDecoderPipelineTest
             .padding(new UnsafeBufferEx(WIRE), 0, WIRE.length);
 
         assertEquals(basePadding + 64, extPadding);
+    }
+
+    @Test
+    public void shouldReportParsingFailureEvent()
+    {
+        ProtobufModelEventType[] kind = new ProtobufModelEventType[1];
+        when(context.clock()).thenReturn(Clock.systemUTC());
+        when(context.supplyEventWriter()).thenReturn(capturingKind(kind));
+        ProtobufModelHandlerImpl handler = newHandler(null);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE, ModelCache.NONE);
+
+        // message index 0 followed by an unterminated variable-length integer (continuation bit set, no
+        // terminating byte) -- malformed wire bytes the parser cannot decode at all, not a schema violation
+        byte[] malformed = {0x00, (byte) 0xFF};
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(malformed), 0, malformed.length, dst, 0, dst.capacity());
+
+        assertEquals(ModelStatus.REJECTED, result.status());
+        assertEquals(ProtobufModelEventType.PARSING_FAILED, kind[0]);
+    }
+
+    @Test
+    public void shouldReportTransformFailureEvent()
+    {
+        ProtobufModelEventType[] kind = new ProtobufModelEventType[1];
+        when(context.clock()).thenReturn(Clock.systemUTC());
+        when(context.supplyEventWriter()).thenReturn(capturingKind(kind));
+        List<ProtobufModelExtContext> exts = List.of(failing());
+        ProtobufModelHandlerImpl handler = newHandler(null, exts);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE, ModelCache.NONE);
+
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(WIRE), 0, WIRE.length, dst, 0, dst.capacity());
+
+        assertEquals(ModelStatus.REJECTED, result.status());
+        assertEquals(ProtobufModelEventType.TRANSFORM_FAILED, kind[0]);
+    }
+
+    // decodes each emitted event's extension kind into the given single-element array, mirroring the
+    // production ProtobufModelEventFormatter's own wrap-and-switch, so a test can assert which event fired
+    // without depending on supplyEventId's (unstubbed, indistinguishable) mocked return value
+    private static MessageConsumer capturingKind(
+        ProtobufModelEventType[] kind)
+    {
+        EventFW eventRO = new EventFW();
+        ProtobufModelEventExFW extensionRO = new ProtobufModelEventExFW();
+        return (msgTypeId, buffer, index, length) ->
+        {
+            EventFW event = eventRO.wrap(buffer, index, index + length);
+            ProtobufModelEventExFW extension = extensionRO
+                .wrap(event.extension().buffer(), event.extension().offset(), event.extension().limit());
+            kind[0] = extension.kind();
+        };
+    }
+
+    // A stage's own exception (not a parsing nor a validation exception) standing in for an extension's
+    // internal failure during its own transform logic.
+    private static ProtobufModelExtContext failing()
+    {
+        return (schema, config) -> new ProtobufModelExtHandler()
+        {
+            @Override
+            public <T extends ProtobufTransformable<T>> T decode(
+                T transformable,
+                ProtobufCache cache)
+            {
+                return transformable.transform(new Failing());
+            }
+        };
+    }
+
+    private static final class Failing implements ProtobufTransform
+    {
+        @Override
+        public ProtobufPipeline.Status transform(
+            ProtobufController control,
+            ProtobufSource source,
+            ProtobufEvent event,
+            ProtobufSink sink)
+        {
+            throw new ProtobufException("extension failure");
+        }
     }
 
     private ProtobufModelHandlerImpl newHandler(

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEventFormatterTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEventFormatterTest.java
@@ -59,4 +59,58 @@ public class ProtobufModelEventFormatterTest
 
         assertEquals("A message payload failed validation. boom.", formatted);
     }
+
+    @Test
+    public void shouldFormatParsingFailedEvent()
+    {
+        EngineContext context = mock(EngineContext.class);
+        when(context.clock()).thenReturn(Clock.systemUTC());
+
+        AtomicReference<DirectBufferEx> captured = new AtomicReference<>();
+        MessageConsumer writer = (msgTypeId, buffer, index, length) ->
+        {
+            MutableDirectBufferEx copy = new UnsafeBufferEx(new byte[length]);
+            copy.putBytes(0, buffer, index, length);
+            captured.set(copy);
+        };
+        when(context.supplyEventWriter()).thenReturn(writer);
+
+        ProtobufModelEventContext events = new ProtobufModelEventContext(context);
+        events.parsingFailure(0L, 0L, "boom");
+
+        ProtobufModelEventFormatterFactory factory = new ProtobufModelEventFormatterFactory();
+        ProtobufModelEventFormatter formatter = factory.create(new Configuration());
+
+        DirectBufferEx event = captured.get();
+        String formatted = formatter.format(event, 0, event.capacity());
+
+        assertEquals("A message payload could not be parsed. boom.", formatted);
+    }
+
+    @Test
+    public void shouldFormatTransformFailedEvent()
+    {
+        EngineContext context = mock(EngineContext.class);
+        when(context.clock()).thenReturn(Clock.systemUTC());
+
+        AtomicReference<DirectBufferEx> captured = new AtomicReference<>();
+        MessageConsumer writer = (msgTypeId, buffer, index, length) ->
+        {
+            MutableDirectBufferEx copy = new UnsafeBufferEx(new byte[length]);
+            copy.putBytes(0, buffer, index, length);
+            captured.set(copy);
+        };
+        when(context.supplyEventWriter()).thenReturn(writer);
+
+        ProtobufModelEventContext events = new ProtobufModelEventContext(context);
+        events.transformFailure(0L, 0L, "boom");
+
+        ProtobufModelEventFormatterFactory factory = new ProtobufModelEventFormatterFactory();
+        ProtobufModelEventFormatter formatter = factory.create(new Configuration());
+
+        DirectBufferEx event = captured.get();
+        String formatted = formatter.format(event, 0, event.capacity());
+
+        assertEquals("A message payload failed to transform. boom.", formatted);
+    }
 }

--- a/specs/model-avro.spec/src/main/resources/META-INF/zilla/avro_model.idl
+++ b/specs/model-avro.spec/src/main/resources/META-INF/zilla/avro_model.idl
@@ -18,7 +18,9 @@ scope avro_model
     {
         enum AvroModelEventType (uint8)
         {
-            VALIDATION_FAILED (1)
+            VALIDATION_FAILED (1),
+            PARSING_FAILED (2),
+            TRANSFORM_FAILED (3)
         }
 
         struct AvroModelValidationFailedEx extends core::stream::Extension
@@ -26,9 +28,21 @@ scope avro_model
             string16 error;
         }
 
+        struct AvroModelParsingFailedEx extends core::stream::Extension
+        {
+            string16 error;
+        }
+
+        struct AvroModelTransformFailedEx extends core::stream::Extension
+        {
+            string16 error;
+        }
+
         union AvroModelEventEx switch (AvroModelEventType)
         {
             case VALIDATION_FAILED: AvroModelValidationFailedEx validationFailed;
+            case PARSING_FAILED: AvroModelParsingFailedEx parsingFailed;
+            case TRANSFORM_FAILED: AvroModelTransformFailedEx transformFailed;
         }
     }
 }

--- a/specs/model-json.spec/src/main/resources/META-INF/zilla/json_model.idl
+++ b/specs/model-json.spec/src/main/resources/META-INF/zilla/json_model.idl
@@ -18,7 +18,9 @@ scope json_model
     {
         enum JsonModelEventType (uint8)
         {
-            VALIDATION_FAILED (1)
+            VALIDATION_FAILED (1),
+            PARSING_FAILED (2),
+            TRANSFORM_FAILED (3)
         }
 
         struct JsonModelValidationFailedEx extends core::stream::Extension
@@ -26,9 +28,21 @@ scope json_model
             string16 error;
         }
 
+        struct JsonModelParsingFailedEx extends core::stream::Extension
+        {
+            string16 error;
+        }
+
+        struct JsonModelTransformFailedEx extends core::stream::Extension
+        {
+            string16 error;
+        }
+
         union JsonModelEventEx switch (JsonModelEventType)
         {
             case VALIDATION_FAILED: JsonModelValidationFailedEx validationFailed;
+            case PARSING_FAILED: JsonModelParsingFailedEx parsingFailed;
+            case TRANSFORM_FAILED: JsonModelTransformFailedEx transformFailed;
         }
     }
 }

--- a/specs/model-protobuf.spec/src/main/resources/META-INF/zilla/protobuf_model.idl
+++ b/specs/model-protobuf.spec/src/main/resources/META-INF/zilla/protobuf_model.idl
@@ -18,7 +18,9 @@ scope protobuf_model
     {
         enum ProtobufModelEventType (uint8)
         {
-            VALIDATION_FAILED (1)
+            VALIDATION_FAILED (1),
+            PARSING_FAILED (2),
+            TRANSFORM_FAILED (3)
         }
 
         struct ProtobufModelValidationFailedEx extends core::stream::Extension
@@ -26,9 +28,21 @@ scope protobuf_model
             string16 error;
         }
 
+        struct ProtobufModelParsingFailedEx extends core::stream::Extension
+        {
+            string16 error;
+        }
+
+        struct ProtobufModelTransformFailedEx extends core::stream::Extension
+        {
+            string16 error;
+        }
+
         union ProtobufModelEventEx switch (ProtobufModelEventType)
         {
             case VALIDATION_FAILED: ProtobufModelValidationFailedEx validationFailed;
+            case PARSING_FAILED: ProtobufModelParsingFailedEx parsingFailed;
+            case TRANSFORM_FAILED: ProtobufModelTransformFailedEx transformFailed;
         }
     }
 }


### PR DESCRIPTION
## Description

Adds a `category()` accessor to `JsonDiagnostic`, `AvroDiagnostic`, and `ProtobufDiagnostic`, backed by a `PARSING` / `VALIDATION` / `TRANSFORM` enum, so a model pipeline's `REJECTED` outcome says *why* it was rejected instead of every rejection being reported as a validation failure.

- Each `XxxPipelineImpl.transform()` populates the category once per existing catch block: the `XxxParsingException` catch is `PARSING`, the `XxxValidationException` catch is `VALIDATION`, and the generic `XxxException` catch-all is `TRANSFORM`.
- Each model's event context/formatter gains `PARSING_FAILED` and `TRANSFORM_FAILED` event kinds alongside the existing `VALIDATION_FAILED`, and each `XxxModelDecoderPipeline` now routes a rejection to the matching event via the new `category()` accessor instead of unconditionally calling `validationFailure(...)`.
- Fixes a related gap this surfaced in Protobuf: `ProtobufReader`/`ProtobufParserImpl` were throwing the generic `ProtobufException` for malformed/structurally non-conformant wire input instead of the more specific `ProtobufParsingException`, and the required-field validator (`ProtobufValidatorImpl`) was throwing the base exception instead of `ProtobufValidationException`. Both now match Avro's existing convention, so `PARSING`/`VALIDATION` are reachable from real input for Protobuf, not just via a custom stage.
- `model-core` (String/Bytes) is out of scope — it reports rejection through a different mechanism (`ModelHandler`'s own `control.reject(...)`, no `XxxDiagnostic` type).

New/extended unit tests cover category assignment in each pipeline and event routing in each decoder pipeline (`common-json`, `common-avro`, `common-protobuf`, `model-json`, `model-avro`, `model-protobuf`). `./mvnw test` passes for all six modules; checkstyle and license checks are clean.

A companion docs PR documents the new `*_PARSING_FAILED`/`*_TRANSFORM_FAILED` events: aklivity/aklivity-docs#115

Fixes #2465

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRoJc8ecBGR8mZSRNzUTm3