### PR TITLE
feat(binding-mcp): add HYDRATE_FAILED telemetry event for route-settle failures

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventContext.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventContext.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.binding.mcp.internal;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventType.AUTHORIZATION_FAILED;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventType.EAGER_INDEX_FAILED;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventType.ELICITATION_TIMEOUT;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventType.HYDRATE_FAILED;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventType.SEARCH_INDEX_FAILED;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventType.SESSION_CLOSED;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventType.SESSION_ESTABLISHED;
@@ -27,6 +28,7 @@ import java.time.Clock;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.EventFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpAuthorizationError;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventExFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
@@ -47,6 +49,7 @@ public final class McpEventContext
     private final int elicitationTimeoutEventId;
     private final int searchIndexFailedEventId;
     private final int eagerIndexFailedEventId;
+    private final int hydrateFailedEventId;
     private final MessageConsumer eventWriter;
     private final Clock clock;
 
@@ -60,6 +63,7 @@ public final class McpEventContext
         this.elicitationTimeoutEventId = context.supplyEventId("binding.mcp.elicitation.timeout");
         this.searchIndexFailedEventId = context.supplyEventId("binding.mcp.search.index.failed");
         this.eagerIndexFailedEventId = context.supplyEventId("binding.mcp.eager.index.failed");
+        this.hydrateFailedEventId = context.supplyEventId("binding.mcp.hydrate.failed");
         this.eventWriter = context.supplyEventWriter();
         this.clock = context.clock();
     }
@@ -198,6 +202,32 @@ public final class McpEventContext
         EventFW event = eventRW
             .wrap(eventBuffer, 0, eventBuffer.capacity())
             .id(eagerIndexFailedEventId)
+            .timestamp(clock.millis())
+            .traceId(traceId)
+            .namespacedId(bindingId)
+            .extension(extension.buffer(), extension.offset(), extension.limit())
+            .build();
+        eventWriter.accept(mcpTypeId, event.buffer(), event.offset(), event.limit());
+    }
+
+    public void hydrateFailed(
+        long traceId,
+        long bindingId,
+        String kind,
+        McpHydrateError error,
+        long retryAt)
+    {
+        McpEventExFW extension = mcpEventExRW
+            .wrap(extensionBuffer, 0, extensionBuffer.capacity())
+            .hydrateFailed(e -> e
+                .typeId(HYDRATE_FAILED.value())
+                .kind(kind)
+                .error(s -> s.set(error))
+                .retryAt(retryAt))
+            .build();
+        EventFW event = eventRW
+            .wrap(eventBuffer, 0, eventBuffer.capacity())
+            .id(hydrateFailedEventId)
             .timestamp(clock.millis())
             .traceId(traceId)
             .namespacedId(bindingId)

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatter.java
@@ -20,6 +20,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpAuthorizati
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEagerIndexFailedExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpElicitationTimeoutExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventExFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateFailedExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpSearchIndexFailedExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpSessionClosedExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpSessionEstablishedExFW;
@@ -91,6 +92,14 @@ public final class McpEventFormatter implements EventFormatterSpi
             McpEagerIndexFailedExFW ex = extension.eagerIndexFailed();
             result = String.format("MCP tool eager index failed. %s",
                     asString(ex.reason()));
+            break;
+        }
+        case HYDRATE_FAILED:
+        {
+            McpHydrateFailedExFW ex = extension.hydrateFailed();
+            result = String.format("MCP cache hydration failed for %s (%s).",
+                    asString(ex.kind()),
+                    ex.error().get());
             break;
         }
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
@@ -98,7 +98,7 @@ public final class McpProxyCache
     public long authorization;
 
     private final StoreHandler store;
-    private final McpEventContext events;
+    final McpEventContext events;
     private final Int2ObjectHashMap<McpListCache> caches;
     private final Long2LongHashMap routeAuthorizations;
     private final List<Runnable> awaiters;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheManager.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheManager.java
@@ -14,7 +14,11 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache;
 
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError.ROUTE_FAILED;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
 
 import java.io.Closeable;
@@ -136,7 +140,8 @@ public final class McpProxyCacheManager implements McpProxyCacheListener
     {
         if (!stopped)
         {
-            scheduleHydrateRetry(kind);
+            final long retryAt = scheduleHydrateRetry(kind);
+            cache.events.hydrateFailed(0L, cache.bindingId, kindName(kind), ROUTE_FAILED, retryAt);
         }
     }
 
@@ -253,15 +258,29 @@ public final class McpProxyCacheManager implements McpProxyCacheListener
     // that steady-state interval rather than permanently giving up; McpProxyCache.markAttempted (called
     // from McpProxyCacheHydrater after this cycle's failure) already lets checkReady()/register() unblock
     // a new session's initialize without needing hydration to ever succeed or stop trying
-    private void scheduleHydrateRetry(
+    private long scheduleHydrateRetry(
         int kind)
     {
         cancelHydrateRetry(kind);
         long delay = hydrateBackoffMs[kind];
         delay = delay == 0L ? cache.leaseRetry.toMillis() : Math.min(delay * 2L, cache.leaseTtl.toMillis());
         hydrateBackoffMs[kind] = delay;
-        hydrateRetryIds[kind] = signaler.signalAt(
-            Instant.now().plusMillis(delay), kind, this::onHydrateRetry);
+        final Instant retryAt = Instant.now().plusMillis(delay);
+        hydrateRetryIds[kind] = signaler.signalAt(retryAt, kind, this::onHydrateRetry);
+        return retryAt.toEpochMilli();
+    }
+
+    private static String kindName(
+        int kind)
+    {
+        return switch (kind)
+        {
+        case KIND_TOOLS_LIST -> "tools";
+        case KIND_PROMPTS_LIST -> "prompts";
+        case KIND_RESOURCES_LIST -> "resources";
+        case KIND_RESOURCES_TEMPLATES_LIST -> "resources/templates";
+        default -> "unknown";
+        };
     }
 
     private void onHydrateRetry(

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatterTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatterTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpAuthorizationError;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
@@ -111,5 +112,14 @@ public class McpEventFormatterTest
         events.eagerIndexFailed(0L, 0L, "eager index backend unavailable");
 
         assertEquals("MCP tool eager index failed. eager index backend unavailable", format());
+    }
+
+    @Test
+    public void shouldFormatHydrateFailedEvent()
+    {
+        McpEventContext events = newEvents();
+        events.hydrateFailed(0L, 0L, "tools", McpHydrateError.ROUTE_FAILED, 1000L);
+
+        assertEquals("MCP cache hydration failed for tools (ROUTE_FAILED).", format());
     }
 }

--- a/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
+++ b/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
@@ -272,7 +272,8 @@ scope mcp
             AUTHORIZATION_FAILED (3),
             ELICITATION_TIMEOUT (4),
             SEARCH_INDEX_FAILED (5),
-            EAGER_INDEX_FAILED (6)
+            EAGER_INDEX_FAILED (6),
+            HYDRATE_FAILED (7)
         }
 
         struct McpSessionEstablishedEx extends core::stream::Extension
@@ -317,6 +318,20 @@ scope mcp
             string16 reason = null;
         }
 
+        enum McpHydrateError (uint8)
+        {
+            PARSE_ERROR(0),
+            INVALID_RESPONSE(1),
+            ROUTE_FAILED(2)
+        }
+
+        struct McpHydrateFailedEx extends core::stream::Extension
+        {
+            string16 kind;
+            McpHydrateError error;
+            int64 retryAt = -1;
+        }
+
         union McpEventEx switch (McpEventType)
         {
             case SESSION_ESTABLISHED: McpSessionEstablishedEx sessionEstablished;
@@ -325,6 +340,7 @@ scope mcp
             case ELICITATION_TIMEOUT: McpElicitationTimeoutEx elicitationTimeout;
             case SEARCH_INDEX_FAILED: McpSearchIndexFailedEx searchIndexFailed;
             case EAGER_INDEX_FAILED: McpEagerIndexFailedEx eagerIndexFailed;
+            case HYDRATE_FAILED: McpHydrateFailedEx hydrateFailed;
         }
     }
 }


### PR DESCRIPTION
## Description

Adds a `McpEventType.HYDRATE_FAILED` telemetry event for the MCP proxy binding's south-route cache-hydration path, per the criteria set out in #2070.

Currently wired for the `ROUTE_FAILED` reason only:

- `mcp.idl`: adds `McpEventType.HYDRATE_FAILED(7)`, the `McpHydrateError` enum (`PARSE_ERROR`, `INVALID_RESPONSE`, `ROUTE_FAILED`), and `McpHydrateFailedEx{kind, error, retryAt=-1}`.
- `McpEventContext` / `McpEventFormatter`: new `hydrateFailed(...)` event method and formatter case, following the existing `searchIndexFailed`/`eagerIndexFailed` pattern.
- `McpProxyCacheManager.onError(kind)`: fires `HYDRATE_FAILED`/`ROUTE_FAILED` with the computed backoff retry time whenever every route for a given list `kind` (tools/prompts/resources) settles as failed during hydration, instead of silently rescheduling.
- Unit test added to `McpEventFormatterTest`, matching existing event-formatter coverage.

**Scope note on `PARSE_ERROR`/`INVALID_RESPONSE`:** the originating issue also proposed firing these two reasons from `McpClientFactory`'s `onDecodeParseError`/`onDecodeInvalidResponse` hooks. On inspection, `McpClientFactory` implements a separate `client` binding kind unrelated to the proxy's south-route cache hydration; the real south-route list-hydration decoder lives in `McpProxyListFactory` and currently has two decode-path gaps of its own (an uncaught `JsonParsingException` on malformed JSON, and a structurally-invalid response being silently cached as an empty success) that need a real fix — not just an event — plus new k3po IT coverage per this repo's test-first discipline. The `McpHydrateError` enum values for `PARSE_ERROR`/`INVALID_RESPONSE` are declared in this PR so the event's shape is settled, but nothing fires them yet; that follow-up is tracked separately.

Fixes #2391 (`ROUTE_FAILED` reason only — see scope note above)

## Test plan

- [x] `./mvnw -pl runtime/binding-mcp test` — 227 tests, 0 failures
- [x] `./mvnw -pl runtime/binding-mcp checkstyle:check` — clean
- [x] New unit test `McpEventFormatterTest#shouldFormatHydrateFailedEvent` covers the event's construction and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ee9xbHZjnVD18LhSNU1UZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016Ee9xbHZjnVD18LhSNU1UZ)_