### PR TITLE
fix(engine): join the worker thread before releasing its buffers on close

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -952,6 +952,7 @@ public class EngineWorker implements EngineContext, Agent
 
     public void doClose()
     {
+        Thread closing = thread;
         try
         {
             Consumer<Thread> timeout = t -> rethrowUnchecked(new IllegalStateException("close timeout"));
@@ -959,6 +960,8 @@ public class EngineWorker implements EngineContext, Agent
         }
         finally
         {
+            awaitTermination(closing);
+
             targetsByIndex.forEach((k, v) -> quietClose(v));
             quietClose(streamsLayout);
             quietClose(bufferPoolLayout);
@@ -966,6 +969,23 @@ public class EngineWorker implements EngineContext, Agent
             quietClose(creditor);
             quietClose(eventWriter);
             thread = null;
+        }
+    }
+
+    private static void awaitTermination(
+        Thread thread)
+    {
+        while (thread != null && thread.isAlive())
+        {
+            try
+            {
+                thread.join(SECONDS.toMillis(5L));
+            }
+            catch (InterruptedException ex)
+            {
+                Thread.currentThread().interrupt();
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
## Description

`EngineWorker.doClose()` bounds the worker's own `AgentRunner.close()` to a 5-second join before throwing `IllegalStateException("close timeout")` back to the caller (`Engine.close()`). On timeout, the throwing `Consumer<Thread>` callback returns immediately — the underlying `runner.close(timeoutMs, consumer)` never actually confirms the worker thread has terminated once its timeout consumer is invoked. `doClose()`'s `finally` block then proceeds to unmap the worker's shared buffers (`streamsLayout`, `bufferPoolLayout`, `eventWriter`, `debitorsByIndex`, `creditor`) regardless, while the worker thread — and any exporter `AgentRunner` it is still synchronously joining inside its own `onClose()` (`onExporterDetached()`'s `runner.close()`, which retries indefinitely rather than failing fast) — can still be reading those buffers, corrupting memory.

Confirmed locally via a JVM crash dump (`hs_err_pid*.log`, SIGSEGV): a background exporter agent thread was mid-`peek()` on an events ring buffer (`OneToOneRingBufferSpy.peek()` → `UnsafeBufferEx$Native.getIntVolatile`) at the exact moment the buffer's backing memory was unmapped from another thread. The exporter's own drain loop (`ExporterAgent.onClose()`, up to a 30s spin plus an unbounded handler-drain) can legitimately outlast the outer worker's 5-second close budget under load, which is enough to trigger this race.

The fix blocks on the worker thread's actual termination before releasing any of its buffers, independent of how long the bounded join inside `runner.close()` took or whether it threw — the diagnostic exception (and its 5-second budget) is preserved for callers, but is no longer allowed to race ahead of the thread it describes.

## Test plan

- [x] `./mvnw clean verify -pl runtime/engine` — full unit + integration test suite, checkstyle, license, and JaCoCo coverage all green with no regressions
- [x] Reproduced the crash upstream (many-iteration back-to-back `EngineRule` start/stop cycles under a downstream consumer's integration test suite) before the fix, confirmed no recurrence (0/~90 runs) after applying it

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CzxN4tJLhiHQ8ikNeuN8WS)_