### PR TITLE
fix(binding-mcp): require exit for kind: client

### DIFF
--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.exit.missing.invalid.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.exit.missing.invalid.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: client
+    options:
+      server: http://localhost:8080/mcp

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.routes.exit.missing.invalid.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.routes.exit.missing.invalid.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: client
+    options:
+      server: http://localhost:8080/mcp
+    routes:
+      - when:
+          - tool: get_weather

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
@@ -217,7 +217,26 @@
                                     }
                                 }
                             },
-                            "required": [ "options" ]
+                            "required": [ "options" ],
+                            "anyOf":
+                            [
+                                {
+                                    "required": [ "exit" ]
+                                },
+                                {
+                                    "required": [ "routes" ],
+                                    "properties":
+                                    {
+                                        "routes":
+                                        {
+                                            "contains":
+                                            {
+                                                "required": [ "exit" ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     {

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/config/SchemaTest.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/config/SchemaTest.java
@@ -132,6 +132,18 @@ public class SchemaTest
     }
 
     @Test(expected = JsonException.class)
+    public void shouldRejectClientWithoutExit()
+    {
+        schema.validate("client.exit.missing.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectClientWithRoutesMissingExit()
+    {
+        schema.validate("client.routes.exit.missing.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
     public void shouldRejectClientWithElicitation()
     {
         schema.validate("client.elicitation.invalid.yaml");


### PR DESCRIPTION
## Description

An `mcp` binding with `kind: client` is a protocol-layering client — it exists to translate the MCP stream into an underlying transport and hand it off south. There is no legitimate configuration where such a binding has nowhere to exit to. Previously a config with no top-level `exit` and no route declaring one passed schema validation and started successfully, but every stream routed to it was reset immediately with no diagnostic.

This adds a JSON schema constraint to the `mcp` binding's `kind: client` branch requiring either:
- a top-level `exit`, or
- at least one route declaring its own `exit`

so the config is rejected at load time instead of failing silently at the stream level.

Also adds two invalid-config fixtures and `SchemaTest` methods covering both failure cases, and confirms the existing valid fixtures (top-level `exit`, and per-route `exit`) are unaffected.

Out of scope: `mcp-http` and `mcp-openapi`'s own `kind: client` already correctly *disallow* `exit` entirely, since those are wire-level termini (like `tcp kind: client`) rather than protocol-layering clients — the opposite case from this issue.

Fixes #2506

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRQUY4eKYGc4vs6yaJHYTa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRQUY4eKYGc4vs6yaJHYTa)_