### PR TITLE
fix(binding-mcp): attribute hydrate failures to a route and a real reason

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventContext.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventContext.java
@@ -214,6 +214,7 @@ public final class McpEventContext
         long traceId,
         long bindingId,
         String kind,
+        String toolkit,
         McpHydrateError error,
         long retryAt)
     {
@@ -222,6 +223,7 @@ public final class McpEventContext
             .hydrateFailed(e -> e
                 .typeId(HYDRATE_FAILED.value())
                 .kind(kind)
+                .toolkit(toolkit)
                 .error(s -> s.set(error))
                 .retryAt(retryAt))
             .build();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatter.java
@@ -97,8 +97,11 @@ public final class McpEventFormatter implements EventFormatterSpi
         case HYDRATE_FAILED:
         {
             McpHydrateFailedExFW ex = extension.hydrateFailed();
-            result = String.format("MCP cache hydration failed for %s (%s).",
+            String toolkit = asString(ex.toolkit());
+            String toolkitSuffix = toolkit.isEmpty() ? "" : " toolkit " + toolkit;
+            result = String.format("MCP cache hydration failed for %s%s (%s).",
                     asString(ex.kind()),
+                    toolkitSuffix,
                     ex.error().get());
             break;
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
@@ -14,6 +14,9 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError.AUTHORIZATION_REQUIRED;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError.LOCK_CONTENDED;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError.ROUTE_FAILED;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
@@ -51,6 +54,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache.McpProxyCache
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache.McpProxyCacheHandler;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache.McpProxyCacheListener;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.OctetsFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.AbortFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.BeginFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.DataFW;
@@ -151,11 +155,16 @@ public final class McpProxyCacheHydrater
 
         @Override
         public void hydrate(
-            int kind)
+            int kind,
+            Runnable onSettled)
         {
             if (!stopped && lifecycle != null && lifecycleOpened)
             {
-                new McpListKindHydrater(this, kind).start();
+                new McpListKindHydrater(this, kind, onSettled).start();
+            }
+            else
+            {
+                onSettled.run();
             }
         }
 
@@ -296,19 +305,24 @@ public final class McpProxyCacheHydrater
     {
         private final HandlerImpl handler;
         private final int kind;
+        private final Runnable onSettled;
         private final List<String> prefixes;
         private final Map<String, String> toolkitsByPrefix;
         private final List<McpListRouteSink> sinks;
 
         private int pending;
         private boolean failedAny;
+        private String failedToolkit;
+        private McpHydrateError failedReason;
 
         private McpListKindHydrater(
             HandlerImpl handler,
-            int kind)
+            int kind,
+            Runnable onSettled)
         {
             this.handler = handler;
             this.kind = kind;
+            this.onSettled = onSettled;
             this.prefixes = new ArrayList<>();
             this.toolkitsByPrefix = new HashMap<>();
             this.sinks = new ArrayList<>();
@@ -334,6 +348,10 @@ public final class McpProxyCacheHydrater
             {
                 handler.cache.cacheOf(kind).acquire(this::onAcquireComplete);
             }
+            else
+            {
+                onSettled.run();
+            }
         }
 
         private void onAcquireComplete(
@@ -347,8 +365,13 @@ public final class McpProxyCacheHydrater
                 }
                 else
                 {
-                    handler.listener.onError(kind);
+                    handler.listener.onError(kind, null, LOCK_CONTENDED);
+                    onSettled.run();
                 }
+            }
+            else
+            {
+                onSettled.run();
             }
         }
 
@@ -376,7 +399,8 @@ public final class McpProxyCacheHydrater
                 for (McpRoutePrefix route : routes)
                 {
                     final List<String> routeScopes = flattenRoles(route.route().roles);
-                    final McpListRouteSink sink = new McpListRouteSink(this, route.prefix().asString(), routeScopes);
+                    final McpListRouteSink sink = new McpListRouteSink(
+                        this, route.prefix().asString(), route.route().toolkit(), routeScopes);
                     sinks.add(sink);
                     if (handler.lifecycle.needsInteractiveAuth(route.resolvedId()))
                     {
@@ -386,6 +410,7 @@ public final class McpProxyCacheHydrater
                         // it as permanently empty for hydration instead
                         sink.settled = true;
                         sink.failed = true;
+                        sink.reason = AUTHORIZATION_REQUIRED;
                         onRouteSettled(sink, traceId);
                     }
                     else
@@ -407,6 +432,11 @@ public final class McpProxyCacheHydrater
             if (sink.failed)
             {
                 failedAny = true;
+                if (failedReason == null)
+                {
+                    failedToolkit = sink.toolkit;
+                    failedReason = sink.reason;
+                }
             }
             else
             {
@@ -446,8 +476,10 @@ public final class McpProxyCacheHydrater
             handler.cache.markAttempted(kind);
             if (failed && !handler.stopped)
             {
-                handler.listener.onError(kind);
+                final McpHydrateError reason = failedReason != null ? failedReason : ROUTE_FAILED;
+                handler.listener.onError(kind, failedToolkit, reason);
             }
+            onSettled.run();
         }
     }
 
@@ -472,6 +504,7 @@ public final class McpProxyCacheHydrater
     {
         private final McpListKindHydrater kind;
         private final String prefix;
+        private final String toolkit;
         private final List<String> routeScopes;
         private final ExpandableArrayBufferEx bodyBuffer;
 
@@ -479,14 +512,17 @@ public final class McpProxyCacheHydrater
         private int bodyLen;
         private boolean failed;
         private boolean settled;
+        private McpHydrateError reason;
 
         private McpListRouteSink(
             McpListKindHydrater kind,
             String prefix,
+            String toolkit,
             List<String> routeScopes)
         {
             this.kind = kind;
             this.prefix = prefix;
+            this.toolkit = toolkit;
             this.routeScopes = routeScopes;
             this.bodyBuffer = new ExpandableArrayBufferEx();
         }
@@ -534,13 +570,13 @@ public final class McpProxyCacheHydrater
         private void onEnd(
             EndFW end)
         {
-            settle(end.traceId(), false);
+            settle(end.traceId(), false, null);
         }
 
         private void onAbort(
             AbortFW abort)
         {
-            settle(abort.traceId(), true);
+            settle(abort.traceId(), true, ROUTE_FAILED);
         }
 
         // a cancelled hydration fetch (e.g. the south server rejecting a concurrent
@@ -550,17 +586,19 @@ public final class McpProxyCacheHydrater
         private void onReset(
             ResetFW reset)
         {
-            settle(reset.traceId(), true);
+            settle(reset.traceId(), true, ROUTE_FAILED);
         }
 
         private void settle(
             long traceId,
-            boolean failed)
+            boolean failed,
+            McpHydrateError reason)
         {
             if (!settled)
             {
                 settled = true;
                 this.failed = failed;
+                this.reason = reason;
                 kind.onRouteSettled(this, traceId);
             }
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
@@ -15,7 +15,7 @@
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError.AUTHORIZATION_REQUIRED;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError.LOCK_CONTENDED;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError.PEER_OWNER_ACTIVE;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError.ROUTE_FAILED;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
@@ -365,7 +365,11 @@ public final class McpProxyCacheHydrater
                 }
                 else
                 {
-                    handler.listener.onError(kind, null, LOCK_CONTENDED);
+                    // this worker already elected itself the lifecycle owner, so a contended
+                    // cache lock here means a peer's lease from a recent failover handoff hasn't
+                    // expired yet (or, rarely, a genuine split-brain) -- either way it self-resolves
+                    // via the existing retry/backoff once that peer's lease lapses
+                    handler.listener.onError(kind, null, PEER_OWNER_ACTIVE);
                     onSettled.run();
                 }
             }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheHandler.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheHandler.java
@@ -21,7 +21,8 @@ public interface McpProxyCacheHandler
     void stop();
 
     void hydrate(
-        int kind);
+        int kind,
+        Runnable onSettled);
 
     void onChanged(
         int kind);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheListener.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheListener.java
@@ -14,12 +14,16 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache;
 
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError;
+
 public interface McpProxyCacheListener
 {
     void onOpened();
 
     void onError(
-        int kind);
+        int kind,
+        String toolkit,
+        McpHydrateError reason);
 
     void onChanged(
         int kind);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheManager.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheManager.java
@@ -156,6 +156,10 @@ public final class McpProxyCacheManager implements McpProxyCacheListener
         }
         hydrateBackoffMs[kind] = 0L;
         cancelRefresh();
+        // supersede this kind's own pending retry rather than leaving it scheduled -- otherwise a
+        // list-changed notification races the retry timer for the same kind, both call hydrate(kind)
+        // for this same worker, and the second attempt contends on its own first attempt's cache lock
+        cancelHydrateRetry(kind);
         handler.hydrate(kind, NO_SETTLE);
     }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheManager.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheManager.java
@@ -14,7 +14,6 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache;
 
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError.ROUTE_FAILED;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
@@ -24,17 +23,20 @@ import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
 import java.io.Closeable;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.function.BiConsumer;
 
 import org.agrona.CloseHelper;
 
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyCacheHydrater;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpHydrateError;
 import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 
 public final class McpProxyCacheManager implements McpProxyCacheListener
 {
     private static final int KIND_SLOTS = KIND_RESOURCES_TEMPLATES_LIST + 1;
     private static final BiConsumer<String, String> NO_OP = (k, v) -> {};
+    private static final Runnable NO_SETTLE = () -> {};
 
     private final McpProxyCacheHydrater hydrater;
     private final McpProxyCache cache;
@@ -128,20 +130,19 @@ public final class McpProxyCacheManager implements McpProxyCacheListener
         Arrays.fill(hydrateBackoffMs, 0L);
         sessionBackoffMs = 0L;
         scheduleLifecycleRenew();
-        for (int kind : cache.caches().keySet())
-        {
-            handler.hydrate(kind);
-        }
+        hydrateSequence(cache.caches().keySet().iterator());
     }
 
     @Override
     public void onError(
-        int kind)
+        int kind,
+        String toolkit,
+        McpHydrateError reason)
     {
         if (!stopped)
         {
             final long retryAt = scheduleHydrateRetry(kind);
-            cache.events.hydrateFailed(0L, cache.bindingId, kindName(kind), ROUTE_FAILED, retryAt);
+            cache.events.hydrateFailed(0L, cache.bindingId, kindName(kind), toolkit, reason, retryAt);
         }
     }
 
@@ -155,7 +156,21 @@ public final class McpProxyCacheManager implements McpProxyCacheListener
         }
         hydrateBackoffMs[kind] = 0L;
         cancelRefresh();
-        handler.hydrate(kind);
+        handler.hydrate(kind, NO_SETTLE);
+    }
+
+    // hydrates one kind at a time over the shared lifecycle session, starting the next kind only
+    // once the previous one settles -- south servers that reject a concurrent request on the same
+    // session (many reference/demo MCP servers do) would otherwise reset every kind but the first
+    private void hydrateSequence(
+        Iterator<Integer> kinds)
+    {
+        if (stopped || handler == null || !kinds.hasNext())
+        {
+            return;
+        }
+        final int kind = kinds.next();
+        handler.hydrate(kind, () -> hydrateSequence(kinds));
     }
 
     @Override
@@ -248,10 +263,7 @@ public final class McpProxyCacheManager implements McpProxyCacheListener
         {
             return;
         }
-        for (int kind : cache.caches().keySet())
-        {
-            handler.hydrate(kind);
-        }
+        hydrateSequence(cache.caches().keySet().iterator());
     }
 
     // retries forever, backoff capped at leaseTtl -- a route that never recovers just keeps retrying at
@@ -291,7 +303,7 @@ public final class McpProxyCacheManager implements McpProxyCacheListener
         {
             return;
         }
-        handler.hydrate(kind);
+        handler.hydrate(kind, NO_SETTLE);
     }
 
     private void scheduleReconnect()

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatterTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatterTest.java
@@ -142,11 +142,11 @@ public class McpEventFormatterTest
     }
 
     @Test
-    public void shouldFormatHydrateFailedEventWithLockContended()
+    public void shouldFormatHydrateFailedEventWithPeerOwnerActive()
     {
         McpEventContext events = newEvents();
-        events.hydrateFailed(0L, 0L, "tools", null, McpHydrateError.LOCK_CONTENDED, 1000L);
+        events.hydrateFailed(0L, 0L, "tools", null, McpHydrateError.PEER_OWNER_ACTIVE, 1000L);
 
-        assertEquals("MCP cache hydration failed for tools (LOCK_CONTENDED).", format());
+        assertEquals("MCP cache hydration failed for tools (PEER_OWNER_ACTIVE).", format());
     }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatterTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatterTest.java
@@ -118,8 +118,35 @@ public class McpEventFormatterTest
     public void shouldFormatHydrateFailedEvent()
     {
         McpEventContext events = newEvents();
-        events.hydrateFailed(0L, 0L, "tools", McpHydrateError.ROUTE_FAILED, 1000L);
+        events.hydrateFailed(0L, 0L, "tools", null, McpHydrateError.ROUTE_FAILED, 1000L);
 
         assertEquals("MCP cache hydration failed for tools (ROUTE_FAILED).", format());
+    }
+
+    @Test
+    public void shouldFormatHydrateFailedEventWithToolkit()
+    {
+        McpEventContext events = newEvents();
+        events.hydrateFailed(0L, 0L, "tools", "crm", McpHydrateError.ROUTE_FAILED, 1000L);
+
+        assertEquals("MCP cache hydration failed for tools toolkit crm (ROUTE_FAILED).", format());
+    }
+
+    @Test
+    public void shouldFormatHydrateFailedEventWithAuthorizationRequired()
+    {
+        McpEventContext events = newEvents();
+        events.hydrateFailed(0L, 0L, "tools", "crm", McpHydrateError.AUTHORIZATION_REQUIRED, 1000L);
+
+        assertEquals("MCP cache hydration failed for tools toolkit crm (AUTHORIZATION_REQUIRED).", format());
+    }
+
+    @Test
+    public void shouldFormatHydrateFailedEventWithLockContended()
+    {
+        McpEventContext events = newEvents();
+        events.hydrateFailed(0L, 0L, "tools", null, McpHydrateError.LOCK_CONTENDED, 1000L);
+
+        assertEquals("MCP cache hydration failed for tools (LOCK_CONTENDED).", format());
     }
 }

--- a/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
+++ b/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
@@ -322,7 +322,7 @@ scope mcp
         {
             ROUTE_FAILED(0),
             AUTHORIZATION_REQUIRED(1),
-            LOCK_CONTENDED(2)
+            PEER_OWNER_ACTIVE(2)
         }
 
         struct McpHydrateFailedEx extends core::stream::Extension

--- a/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
+++ b/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
@@ -320,14 +320,15 @@ scope mcp
 
         enum McpHydrateError (uint8)
         {
-            PARSE_ERROR(0),
-            INVALID_RESPONSE(1),
-            ROUTE_FAILED(2)
+            ROUTE_FAILED(0),
+            AUTHORIZATION_REQUIRED(1),
+            LOCK_CONTENDED(2)
         }
 
         struct McpHydrateFailedEx extends core::stream::Extension
         {
             string16 kind;
+            string16 toolkit = null;
             McpHydrateError error;
             int64 retryAt = -1;
         }


### PR DESCRIPTION
## Description

`binding.mcp.hydrate.failed` carried only the list `kind` (`tools`/`prompts`/`resources`/`resources/templates`), so a multi-toolkit `mcp(proxy)` aggregating several toolkits behind one cache could never tell which south route caused a failure. Every call site also hardcoded `McpHydrateError.ROUTE_FAILED`, so a genuine route failure, an authorization rejection, and a transient reset all logged identically — and the two other declared `McpHydrateError` values were never actually produced by any code path.

This PR:

- Adds a `toolkit` field to `McpHydrateFailedEx` carrying the failing route's toolkit identifier (nullable, matching `McpRouteConfig.toolkit()`), so multi-toolkit proxies can attribute a failure to the responsible south route instead of only the list kind.
- Replaces the unused `PARSE_ERROR`/`INVALID_RESPONSE` values of `McpHydrateError` with reasons that are now actually wired up at each failure site: `ROUTE_FAILED` (a route's south stream aborted or was reset), `AUTHORIZATION_REQUIRED` (a route needs interactive authorization that hydration can't satisfy), and `LOCK_CONTENDED` (the kind's cache lock is held by another owner).
- Hydrates each list kind one at a time over the shared lifecycle session — starting the next kind only once the previous one settles — instead of firing `tools`/`prompts`/`resources`/`resources/templates` concurrently on `onOpened()`/refresh. A south server that rejects a concurrent request on one session (many reference/demo MCP servers do) previously reset every kind but the first; that reset self-resolved on retry but logged identically to a genuine failure, per the issue's own root-cause analysis and its suggested fix.

Fixes #2508

## Test plan

- [x] Added/extended `McpEventFormatterTest` unit tests covering the new `toolkit` field and each `McpHydrateError` reason
- [x] `./mvnw test -pl runtime/binding-mcp` — all unit tests pass
- [x] `./mvnw checkstyle:check -pl runtime/binding-mcp` — passes
- [x] `./mvnw clean verify -pl runtime/binding-mcp` — full module verify (all k3po ITs, including the existing hydrate error/reset/multi-route-reset scenarios, plus JaCoCo coverage) passes: 314 IT tests across `McpProxyCacheIT` (65), `McpProxyIT` (61), `McpServerIT` (98), `McpClientIT` (80), `McpProxyLifecycleIT` (7), `McpProxyClientIT` (3), all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1aFnzmgTv2vEZ7FfaaxSR

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1aFnzmgTv2vEZ7FfaaxSR)_