### PR TITLE
feat(engine): batch EmbeddingHandler.embed(), fix(binding-mcp): tolerate a failing search backend

### DIFF
--- a/incubator/embedding-glove/src/main/java/io/aklivity/zilla/runtime/embedding/glove/internal/GloveEmbeddingHandler.java
+++ b/incubator/embedding-glove/src/main/java/io/aklivity/zilla/runtime/embedding/glove/internal/GloveEmbeddingHandler.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -65,11 +66,15 @@ public final class GloveEmbeddingHandler implements EmbeddingHandler, AutoClosea
         long traceId,
         long bindingId,
         long contextId,
-        String text,
+        List<String> texts,
         CompletionCallback completion)
     {
-        float[] embedding = embed(text);
-        context.dispatch(() -> completion.completed(contextId, embedding));
+        float[][] results = new float[texts.size()][];
+        for (int i = 0; i < texts.size(); i++)
+        {
+            results[i] = embed(texts.get(i));
+        }
+        context.dispatch(() -> completion.completed(contextId, results));
     }
 
     @Override

--- a/incubator/model-vector/src/main/java/io/aklivity/zilla/runtime/model/vector/internal/VectorModelHandlerImpl.java
+++ b/incubator/model-vector/src/main/java/io/aklivity/zilla/runtime/model/vector/internal/VectorModelHandlerImpl.java
@@ -53,28 +53,30 @@ final class VectorModelHandlerImpl implements ModelHandler
         this.pending = new LinkedList<>();
         this.rejectVectors = new float[config.reject.size()][];
 
-        for (int i = 0; i < config.reject.size(); i++)
+        handler.embed(0L, 0L, 0L, config.reject, new EmbeddingHandler.CompletionCallback()
         {
-            final int index = i;
-            handler.embed(0L, 0L, 0L, config.reject.get(i), new EmbeddingHandler.CompletionCallback()
+            @Override
+            public void completed(
+                long contextId,
+                float[][] results)
             {
-                @Override
-                public void completed(
-                    long contextId,
-                    float[] result)
+                for (int i = 0; i < results.length; i++)
                 {
-                    onRejectVectorEmbedded(index, result);
+                    onRejectVectorEmbedded(i, results[i]);
                 }
+            }
 
-                @Override
-                public void failed(
-                    long contextId,
-                    Throwable ex)
+            @Override
+            public void failed(
+                long contextId,
+                Throwable ex)
+            {
+                for (int i = 0; i < rejectVectors.length; i++)
                 {
-                    onRejectVectorEmbedded(index, null);
+                    onRejectVectorEmbedded(i, null);
                 }
-            });
-        }
+            }
+        });
     }
 
     @Override
@@ -118,7 +120,7 @@ final class VectorModelHandlerImpl implements ModelHandler
         String text,
         EmbeddingHandler.CompletionCallback callback)
     {
-        handler.embed(traceId, bindingId, 0L, text, callback);
+        handler.embed(traceId, bindingId, 0L, List.of(text), callback);
     }
 
     void whenReady(

--- a/incubator/model-vector/src/main/java/io/aklivity/zilla/runtime/model/vector/internal/VectorModelPipeline.java
+++ b/incubator/model-vector/src/main/java/io/aklivity/zilla/runtime/model/vector/internal/VectorModelPipeline.java
@@ -136,9 +136,9 @@ final class VectorModelPipeline implements ModelPipeline
             @Override
             public void completed(
                 long contextId,
-                float[] vector)
+                float[][] results)
             {
-                onEmbedded(expectedGeneration, handler.matches(vector));
+                onEmbedded(expectedGeneration, handler.matches(results[0]));
             }
 
             @Override

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchComposite.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchComposite.java
@@ -30,8 +30,9 @@ import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
  * <p>
  * Fans an {@link #index(Collection, CompletionCallback)} or {@link #query(String,
  * CompletionCallback)} call out to every configured backend and joins once all have
- * completed; the first failure reported by any backend is forwarded as the composite's own
- * failure, discarding any results still outstanding from the others.
+ * completed. A backend that fails contributes no results rather than failing the
+ * composite; the composite itself fails only once every backend has failed, forwarding
+ * the last-reported failure.
  * </p>
  */
 public final class McpToolSearchComposite implements McpToolSearchIndex
@@ -56,7 +57,8 @@ public final class McpToolSearchComposite implements McpToolSearchIndex
         else
         {
             final int[] remaining = { indexes.size() };
-            final boolean[] settled = { false };
+            final int[] failures = { 0 };
+            final Throwable[] lastFailure = { null };
 
             for (McpToolSearchIndex index : indexes)
             {
@@ -66,21 +68,30 @@ public final class McpToolSearchComposite implements McpToolSearchIndex
                     public void completed(
                         Void result)
                     {
-                        if (--remaining[0] == 0 && !settled[0])
-                        {
-                            settled[0] = true;
-                            completed.completed(null);
-                        }
+                        onSettled();
                     }
 
                     @Override
                     public void failed(
                         Throwable ex)
                     {
-                        if (!settled[0])
+                        failures[0]++;
+                        lastFailure[0] = ex;
+                        onSettled();
+                    }
+
+                    private void onSettled()
+                    {
+                        if (--remaining[0] == 0)
                         {
-                            settled[0] = true;
-                            completed.failed(ex);
+                            if (failures[0] == indexes.size())
+                            {
+                                completed.failed(lastFailure[0]);
+                            }
+                            else
+                            {
+                                completed.completed(null);
+                            }
                         }
                     }
                 });
@@ -99,9 +110,10 @@ public final class McpToolSearchComposite implements McpToolSearchIndex
         }
         else
         {
-            final List<List<McpToolSearchMatch>> rankings = new ArrayList<>(Collections.nCopies(indexes.size(), null));
+            final List<List<McpToolSearchMatch>> rankings = new ArrayList<>(Collections.nCopies(indexes.size(), List.of()));
             final int[] remaining = { indexes.size() };
-            final boolean[] settled = { false };
+            final int[] failures = { 0 };
+            final Throwable[] lastFailure = { null };
 
             for (int i = 0; i < indexes.size(); i++)
             {
@@ -113,21 +125,30 @@ public final class McpToolSearchComposite implements McpToolSearchIndex
                         List<McpToolSearchMatch> matches)
                     {
                         rankings.set(slot, matches);
-                        if (--remaining[0] == 0 && !settled[0])
-                        {
-                            settled[0] = true;
-                            completed.completed(McpToolSearchRankFusion.fuse(rankings));
-                        }
+                        onSettled();
                     }
 
                     @Override
                     public void failed(
                         Throwable ex)
                     {
-                        if (!settled[0])
+                        failures[0]++;
+                        lastFailure[0] = ex;
+                        onSettled();
+                    }
+
+                    private void onSettled()
+                    {
+                        if (--remaining[0] == 0)
                         {
-                            settled[0] = true;
-                            completed.failed(ex);
+                            if (failures[0] == indexes.size())
+                            {
+                                completed.failed(lastFailure[0]);
+                            }
+                            else
+                            {
+                                completed.completed(McpToolSearchRankFusion.fuse(rankings));
+                            }
                         }
                     }
                 });

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchCompositeTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchCompositeTest.java
@@ -100,12 +100,110 @@ public class McpToolSearchCompositeTest
     }
 
     @Test
-    public void shouldForwardFirstFailureExactlyOnce()
+    public void shouldCompleteIndexWhenOneBackendFails()
+    {
+        FakeIndex first = new FakeIndex();
+        FakeIndex second = new FakeIndex();
+        McpToolSearchComposite composite = new McpToolSearchComposite(List.of(first, second));
+        int[] completions = { 0 };
+
+        composite.index(List.of(), new McpToolSearchIndex.CompletionCallback<Void>()
+        {
+            @Override
+            public void completed(
+                Void result)
+            {
+                completions[0]++;
+            }
+
+            @Override
+            public void failed(
+                Throwable ex)
+            {
+                throw new AssertionError(ex);
+            }
+        });
+
+        first.failIndex(new RuntimeException("embedding provider unavailable"));
+        second.completeIndex();
+
+        assertThat(completions[0], equalTo(1));
+    }
+
+    @Test
+    public void shouldFailIndexOnlyWhenEveryBackendFails()
+    {
+        FakeIndex first = new FakeIndex();
+        FakeIndex second = new FakeIndex();
+        McpToolSearchComposite composite = new McpToolSearchComposite(List.of(first, second));
+        RuntimeException firstFailure = new RuntimeException("embedding provider unavailable");
+        RuntimeException secondFailure = new RuntimeException("keyword index not ready");
+        int[] failures = { 0 };
+
+        composite.index(List.of(), new McpToolSearchIndex.CompletionCallback<Void>()
+        {
+            @Override
+            public void completed(
+                Void result)
+            {
+                throw new AssertionError("expected failure");
+            }
+
+            @Override
+            public void failed(
+                Throwable ex)
+            {
+                assertThat(ex, sameInstance(secondFailure));
+                failures[0]++;
+            }
+        });
+
+        first.failIndex(firstFailure);
+        second.failIndex(secondFailure);
+
+        assertThat(failures[0], equalTo(1));
+    }
+
+    @Test
+    public void shouldFuseSuccessfulResultsWhenOneBackendFails()
     {
         FakeIndex first = new FakeIndex();
         FakeIndex second = new FakeIndex();
         McpToolSearchComposite composite = new McpToolSearchComposite(List.of(first, second));
         RuntimeException failure = new RuntimeException("embedding provider unavailable");
+        List<McpToolSearchMatch>[] fused = new List[1];
+
+        composite.query("kafka", new McpToolSearchIndex.CompletionCallback<List<McpToolSearchMatch>>()
+        {
+            @Override
+            public void completed(
+                List<McpToolSearchMatch> matches)
+            {
+                fused[0] = matches;
+            }
+
+            @Override
+            public void failed(
+                Throwable ex)
+            {
+                throw new AssertionError(ex);
+            }
+        });
+
+        first.failQuery(failure);
+        second.completeQuery(List.of(new McpToolSearchMatch("b", 9.0)));
+
+        assertThat(names(fused[0]), contains("b"));
+    }
+
+    @Test
+    public void shouldFailOnlyWhenEveryBackendFails()
+    {
+        FakeIndex first = new FakeIndex();
+        FakeIndex second = new FakeIndex();
+        McpToolSearchComposite composite = new McpToolSearchComposite(List.of(first, second));
+        RuntimeException firstFailure = new RuntimeException("embedding provider unavailable");
+        RuntimeException secondFailure = new RuntimeException("keyword index not ready");
         int[] failures = { 0 };
 
         composite.query("kafka", new McpToolSearchIndex.CompletionCallback<List<McpToolSearchMatch>>()
@@ -121,13 +219,13 @@ public class McpToolSearchCompositeTest
             public void failed(
                 Throwable ex)
             {
-                assertThat(ex, sameInstance(failure));
+                assertThat(ex, sameInstance(secondFailure));
                 failures[0]++;
             }
         });
 
-        first.failQuery(failure);
-        second.completeQuery(List.of());
+        first.failQuery(firstFailure);
+        second.failQuery(secondFailure);
 
         assertThat(failures[0], equalTo(1));
     }
@@ -200,6 +298,12 @@ public class McpToolSearchCompositeTest
             Throwable ex)
         {
             queryCallback.failed(ex);
+        }
+
+        private void failIndex(
+            Throwable ex)
+        {
+            indexCallback.failed(ex);
         }
     }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/embedding/EmbeddingHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/embedding/EmbeddingHandler.java
@@ -15,6 +15,8 @@
  */
 package io.aklivity.zilla.runtime.engine.embedding;
 
+import java.util.List;
+
 /**
  * Produces embedding vectors for a specific embedding configuration.
  * <p>
@@ -34,13 +36,22 @@ package io.aklivity.zilla.runtime.engine.embedding;
  * the caller observes "callback runs on my thread, later", and never has to handle a
  * reentrant completion.
  * </p>
+ * <p>
+ * <b>Always batched.</b> {@link #embed} takes a list of texts, not a single text, so a
+ * caller resolving many embeddings at once (for example, indexing a corpus of documents)
+ * can hand them to a single call rather than issuing one call per text. A provider whose
+ * remote API accepts multiple texts per request can then satisfy the whole batch in as few
+ * underlying requests as its API allows, rather than one request per text — the difference
+ * between one request and dozens against a rate-limited API. A caller with exactly one text
+ * to embed (for example, a single search query) passes a single-element list.
+ * </p>
  *
  * @see EmbeddingContext
  */
 public interface EmbeddingHandler
 {
     /**
-     * Resolves an embedding for {@code text}, asynchronously.
+     * Resolves an embedding for each of {@code texts}, in order, asynchronously.
      * <p>
      * The {@code contextId} supplied at the call site is echoed back through the callback
      * so a single shared {@link CompletionCallback} instance can route results to the
@@ -51,23 +62,25 @@ public interface EmbeddingHandler
      * @param traceId     the trace identifier for diagnostics
      * @param bindingId   the binding identifier requesting the embedding
      * @param contextId   a context identifier (e.g., stream id), echoed back to {@code completion}
-     * @param text        the text to embed
-     * @param completion  callback invoked with the embedding vector on success ({@code null}
-     *                    result if no embedding could be produced), or
+     * @param texts       the texts to embed, in order
+     * @param completion  callback invoked with one embedding vector per text, in the same
+     *                    order, on success (an individual vector is {@code null} if no
+     *                    embedding could be produced for that text), or
      *                    {@link CompletionCallback#failed} if the attempt failed
      */
     void embed(
         long traceId,
         long bindingId,
         long contextId,
-        String text,
+        List<String> texts,
         CompletionCallback completion);
 
     /**
-     * Completion handler for the async {@link #embed(long, long, long, String, CompletionCallback)}
-     * operation, modelled after {@code GuardHandler.CompletionCallback}. The {@code contextId}
-     * supplied by the caller is echoed back to both methods so a single shared callback instance
-     * can dispatch results to the originating stream without per-call lambda capture.
+     * Completion handler for the async
+     * {@link #embed(long, long, long, List, CompletionCallback)} operation, modelled after
+     * {@code GuardHandler.CompletionCallback}. The {@code contextId} supplied by the caller
+     * is echoed back to both methods so a single shared callback instance can dispatch
+     * results to the originating stream without per-call lambda capture.
      */
     interface CompletionCallback
     {
@@ -75,11 +88,13 @@ public interface EmbeddingHandler
          * Invoked when the operation completes successfully.
          *
          * @param contextId  the {@code contextId} supplied to the originating call
-         * @param result     the embedding vector, or {@code null} if no embedding could be produced
+         * @param results    one embedding vector per requested text, in the same order;
+         *                    an individual vector is {@code null} if no embedding could be
+         *                    produced for that text
          */
         void completed(
             long contextId,
-            float[] result);
+            float[][] results);
 
         /**
          * Invoked when the operation fails.

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -262,12 +262,12 @@ final class TestBindingFactory implements BindingHandler
                 {
                     final Thread dispatchThread = Thread.currentThread();
                     final MutableBoolean callbackFired = new MutableBoolean();
-                    this.embedding.embed(0L, binding.id, 0L, "init", new EmbeddingHandler.CompletionCallback()
+                    this.embedding.embed(0L, binding.id, 0L, List.of("init"), new EmbeddingHandler.CompletionCallback()
                     {
                         @Override
                         public void completed(
                             long contextId,
-                            float[] result)
+                            float[][] results)
                         {
                             if (Thread.currentThread() != dispatchThread || callbackFired.value)
                             {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/embedding/TestEmbeddingHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/embedding/TestEmbeddingHandler.java
@@ -15,6 +15,7 @@
  */
 package io.aklivity.zilla.runtime.engine.test.internal.embedding;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 import io.aklivity.zilla.runtime.engine.embedding.EmbeddingHandler;
@@ -37,20 +38,25 @@ public final class TestEmbeddingHandler implements EmbeddingHandler
         long traceId,
         long bindingId,
         long contextId,
-        String text,
+        List<String> texts,
         CompletionCallback completion)
     {
-        dispatcher.accept(() -> complete(contextId, text, completion));
+        dispatcher.accept(() -> complete(contextId, texts, completion));
     }
 
     private void complete(
         long contextId,
-        String text,
+        List<String> texts,
         CompletionCallback completion)
     {
         try
         {
-            completion.completed(contextId, generate(text));
+            float[][] results = new float[texts.size()][];
+            for (int i = 0; i < texts.size(); i++)
+            {
+                results[i] = generate(texts.get(i));
+            }
+            completion.completed(contextId, results);
         }
         catch (Throwable ex)
         {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/embedding/TestEmbeddingHandlerTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/embedding/TestEmbeddingHandlerTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
+import java.util.List;
 import java.util.function.Consumer;
 
 import org.junit.Test;
@@ -55,17 +56,17 @@ public class TestEmbeddingHandlerTest
         float[] expected = TestEmbeddingHandler.generate("hello world");
 
         boolean[] completed = new boolean[1];
-        float[][] captured = new float[1][];
-        handler.embed(0L, 0L, 42L, "hello world", new EmbeddingHandler.CompletionCallback()
+        float[][][] captured = new float[1][][];
+        handler.embed(0L, 0L, 42L, List.of("hello world"), new EmbeddingHandler.CompletionCallback()
         {
             @Override
             public void completed(
                 long contextId,
-                float[] result)
+                float[][] results)
             {
                 assertEquals(42L, contextId);
                 completed[0] = true;
-                captured[0] = result;
+                captured[0] = results;
             }
 
             @Override
@@ -83,6 +84,7 @@ public class TestEmbeddingHandlerTest
         deferred.poll().run();
 
         assertTrue(completed[0]);
-        assertArrayEquals(expected, captured[0], 0.0f);
+        assertEquals(1, captured[0].length);
+        assertArrayEquals(expected, captured[0][0], 0.0f);
     }
 }


### PR DESCRIPTION
## Summary
- `EmbeddingHandler.embed()` now always takes `List<String>` and returns `float[][]` (one vector per text, in order) instead of a single text/vector per call. No separate batch method — a single text is just a one-element list. This lets a caller resolving many embeddings at once (e.g. indexing a corpus of documents for search) ask a provider for as many as its own API accepts per request, instead of being forced into one request per text.
- `McpToolSearchComposite` fix: fanning `index()`/`query()` out to multiple configured backends previously forwarded the *first* failure from *any* backend as the composite's own failure, discarding whatever the other backends already found. A failing backend now contributes nothing rather than failing the whole composite; the composite fails only once every backend has failed.
- Updated the engine's own `TestEmbeddingHandler`/`TestBindingFactory` SPI test doubles to the new signature.

## Test plan
- [x] `runtime/engine` unit tests pass (54 test classes)
- [x] `runtime/binding-mcp` unit tests pass (33 test classes), including new/updated `McpToolSearchCompositeTest` cases covering partial-backend-failure fusion and all-backends-fail propagation
- [x] Verified end-to-end downstream against a real embedding provider (batched request replaces what was previously N single-text requests; composite fix confirmed to preserve keyword-backend results when the semantic backend independently fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)