### PR TITLE
fix(binding-mcp-kafka): avoid NPE on unrecognized JSON in tool call arguments

### DIFF
--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolAllTopicsSource.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolAllTopicsSource.java
@@ -44,7 +44,8 @@ public final class McpKafkaToolAllTopicsSource implements JsonSink, Source
     private enum Context
     {
         ROOT,
-        ARGUMENTS
+        ARGUMENTS,
+        IGNORED
     }
 
     private final Deque<Context> stack = new ArrayDeque<>();
@@ -106,7 +107,9 @@ public final class McpKafkaToolAllTopicsSource implements JsonSink, Source
             status = onEndObject();
             break;
         case START_ARRAY:
-            stack.push(null);
+            // ArrayDeque forbids null elements, so IGNORED stands in for null to keep the stack
+            // depth correct while still ignoring any array content, including under "arguments".
+            stack.push(Context.IGNORED);
             break;
         case END_ARRAY:
             stack.pop();
@@ -140,7 +143,9 @@ public final class McpKafkaToolAllTopicsSource implements JsonSink, Source
         }
         else
         {
-            next = null;
+            // ArrayDeque forbids null elements, so an unrecognized object (e.g. a JSON-RPC "_meta"
+            // sibling of "arguments") pushes IGNORED rather than null to keep the stack depth correct.
+            next = Context.IGNORED;
         }
         stack.push(next);
     }

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolAlterConfigsSource.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolAlterConfigsSource.java
@@ -75,7 +75,8 @@ public final class McpKafkaToolAlterConfigsSource implements JsonSink, Source, S
     {
         ROOT,
         ARGUMENTS,
-        CONFIGS
+        CONFIGS,
+        IGNORED
     }
 
     private final Deque<Context> stack = new ArrayDeque<>();
@@ -219,7 +220,9 @@ public final class McpKafkaToolAlterConfigsSource implements JsonSink, Source, S
         }
         else
         {
-            next = null;
+            // ArrayDeque forbids null elements, so an unrecognized object (e.g. a JSON-RPC "_meta"
+            // sibling of "arguments") pushes IGNORED rather than null to keep the stack depth correct.
+            next = Context.IGNORED;
         }
         stack.push(next);
     }

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolCreateAclsSource.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolCreateAclsSource.java
@@ -67,7 +67,8 @@ public final class McpKafkaToolCreateAclsSource implements JsonSink, Source
         ROOT,
         ARGUMENTS,
         ACLS,
-        ACL
+        ACL,
+        IGNORED
     }
 
     private final Deque<Context> stack = new ArrayDeque<>();
@@ -191,7 +192,9 @@ public final class McpKafkaToolCreateAclsSource implements JsonSink, Source
         }
         else
         {
-            next = null;
+            // ArrayDeque forbids null elements, so an unrecognized object (e.g. a JSON-RPC "_meta"
+            // sibling of "arguments") pushes IGNORED rather than null to keep the stack depth correct.
+            next = Context.IGNORED;
         }
         stack.push(next);
     }
@@ -206,7 +209,7 @@ public final class McpKafkaToolCreateAclsSource implements JsonSink, Source
         }
         else
         {
-            next = null;
+            next = Context.IGNORED;
         }
         stack.push(next);
     }

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolCreateTopicsSource.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolCreateTopicsSource.java
@@ -74,7 +74,8 @@ public final class McpKafkaToolCreateTopicsSource implements JsonSink, Source
         ASSIGNMENTS,
         ASSIGNMENT,
         BROKERS,
-        CONFIGS
+        CONFIGS,
+        IGNORED
     }
 
     private final int defaultTimeoutMs;
@@ -235,7 +236,9 @@ public final class McpKafkaToolCreateTopicsSource implements JsonSink, Source
         }
         else
         {
-            next = null;
+            // ArrayDeque forbids null elements, so an unrecognized object (e.g. a JSON-RPC "_meta"
+            // sibling of "arguments") pushes IGNORED rather than null to keep the stack depth correct.
+            next = Context.IGNORED;
         }
         stack.push(next);
     }
@@ -296,7 +299,7 @@ public final class McpKafkaToolCreateTopicsSource implements JsonSink, Source
         }
         else
         {
-            next = null;
+            next = Context.IGNORED;
         }
         stack.push(next);
     }

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDeleteAclsSource.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDeleteAclsSource.java
@@ -59,7 +59,8 @@ public final class McpKafkaToolDeleteAclsSource implements JsonSink, Source
         ROOT,
         ARGUMENTS,
         ACLS,
-        ACL
+        ACL,
+        IGNORED
     }
 
     private final Deque<Context> stack = new ArrayDeque<>();
@@ -183,7 +184,9 @@ public final class McpKafkaToolDeleteAclsSource implements JsonSink, Source
         }
         else
         {
-            next = null;
+            // ArrayDeque forbids null elements, so an unrecognized object (e.g. a JSON-RPC "_meta"
+            // sibling of "arguments") pushes IGNORED rather than null to keep the stack depth correct.
+            next = Context.IGNORED;
         }
         stack.push(next);
     }
@@ -198,7 +201,7 @@ public final class McpKafkaToolDeleteAclsSource implements JsonSink, Source
         }
         else
         {
-            next = null;
+            next = Context.IGNORED;
         }
         stack.push(next);
     }

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDeleteTopicsSource.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDeleteTopicsSource.java
@@ -52,7 +52,8 @@ public final class McpKafkaToolDeleteTopicsSource implements JsonSink, Source
     {
         ROOT,
         ARGUMENTS,
-        TOPICS
+        TOPICS,
+        IGNORED
     }
 
     private final int defaultTimeoutMs;
@@ -169,7 +170,9 @@ public final class McpKafkaToolDeleteTopicsSource implements JsonSink, Source
         }
         else
         {
-            next = null;
+            // ArrayDeque forbids null elements, so an unrecognized object (e.g. a JSON-RPC "_meta"
+            // sibling of "arguments") pushes IGNORED rather than null to keep the stack depth correct.
+            next = Context.IGNORED;
         }
         stack.push(next);
     }
@@ -198,7 +201,7 @@ public final class McpKafkaToolDeleteTopicsSource implements JsonSink, Source
     private void onStartArray()
     {
         final Context parent = current();
-        final Context next = parent == Context.ARGUMENTS && "topics".equals(key) ? Context.TOPICS : null;
+        final Context next = parent == Context.ARGUMENTS && "topics".equals(key) ? Context.TOPICS : Context.IGNORED;
         stack.push(next);
     }
 

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDescribeConfigsSource.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDescribeConfigsSource.java
@@ -66,7 +66,8 @@ public final class McpKafkaToolDescribeConfigsSource implements JsonSink, Source
     private enum Context
     {
         ROOT,
-        ARGUMENTS
+        ARGUMENTS,
+        IGNORED
     }
 
     private final Deque<Context> stack = new ArrayDeque<>();
@@ -197,7 +198,9 @@ public final class McpKafkaToolDescribeConfigsSource implements JsonSink, Source
         }
         else
         {
-            next = null;
+            // ArrayDeque forbids null elements, so an unrecognized object (e.g. a JSON-RPC "_meta"
+            // sibling of "arguments") pushes IGNORED rather than null to keep the stack depth correct.
+            next = Context.IGNORED;
         }
         stack.push(next);
     }

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDescribeTopicSource.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDescribeTopicSource.java
@@ -45,7 +45,8 @@ public final class McpKafkaToolDescribeTopicSource implements JsonSink, Source
     private enum Context
     {
         ROOT,
-        ARGUMENTS
+        ARGUMENTS,
+        IGNORED
     }
 
     private final Deque<Context> stack = new ArrayDeque<>();
@@ -151,7 +152,9 @@ public final class McpKafkaToolDescribeTopicSource implements JsonSink, Source
         }
         else
         {
-            next = null;
+            // ArrayDeque forbids null elements, so an unrecognized object (e.g. a JSON-RPC "_meta"
+            // sibling of "arguments") pushes IGNORED rather than null to keep the stack depth correct.
+            next = Context.IGNORED;
         }
         stack.push(next);
     }

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolListAclsSource.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolListAclsSource.java
@@ -53,7 +53,8 @@ public final class McpKafkaToolListAclsSource implements JsonSink, Source
     private enum Context
     {
         ROOT,
-        ARGUMENTS
+        ARGUMENTS,
+        IGNORED
     }
 
     private final Deque<Context> stack = new ArrayDeque<>();
@@ -192,7 +193,9 @@ public final class McpKafkaToolListAclsSource implements JsonSink, Source
         }
         else
         {
-            next = null;
+            // ArrayDeque forbids null elements, so an unrecognized object (e.g. a JSON-RPC "_meta"
+            // sibling of "arguments") pushes IGNORED rather than null to keep the stack depth correct.
+            next = Context.IGNORED;
         }
         stack.push(next);
     }

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolAllTopicsSourceTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolAllTopicsSourceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.kafka.internal.transform;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+
+public class McpKafkaToolAllTopicsSourceTest
+{
+    @Test
+    public void shouldCompleteWithEmptyArguments()
+    {
+        McpKafkaToolAllTopicsSource source = new McpKafkaToolAllTopicsSource();
+
+        Status status = parse(source, "{\"arguments\":{}}");
+
+        assertEquals(Status.COMPLETED, status);
+        assertTrue(source.completed());
+        assertTrue(source.allTopics());
+        assertEquals(0, source.topicCount());
+    }
+
+    @Test
+    public void shouldIgnoreMetaSiblingOfArguments()
+    {
+        McpKafkaToolAllTopicsSource source = new McpKafkaToolAllTopicsSource();
+
+        Status status = parse(source,
+            "{\"name\":\"list_topics\",\"arguments\":{},\"_meta\":{\"progressToken\":1}}");
+
+        assertEquals(Status.COMPLETED, status);
+        assertTrue(source.completed());
+    }
+
+    @Test
+    public void shouldResetBetweenCalls()
+    {
+        McpKafkaToolAllTopicsSource source = new McpKafkaToolAllTopicsSource();
+
+        parse(source, "{\"arguments\":{}}");
+        assertTrue(source.completed());
+
+        source.reset();
+
+        assertEquals(false, source.completed());
+    }
+
+    private static Status parse(
+        McpKafkaToolAllTopicsSource source,
+        String json)
+    {
+        final JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(source);
+        pipeline.reset();
+
+        final byte[] in = json.getBytes(UTF_8);
+        final MutableDirectBufferEx src = new UnsafeBufferEx(new byte[in.length]);
+        src.putBytes(0, in);
+
+        return pipeline.transform(src, 0, in.length);
+    }
+}

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolAlterConfigsSourceTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolAlterConfigsSourceTest.java
@@ -74,6 +74,20 @@ public class McpKafkaToolAlterConfigsSourceTest
     }
 
     @Test
+    public void shouldIgnoreMetaSiblingOfArguments()
+    {
+        McpKafkaToolAlterConfigsSource source =
+            new McpKafkaToolAlterConfigsSource(KafkaAlterConfigsRequest.RESOURCE_TYPE_TOPIC);
+
+        Status status = parse(source,
+            "{\"name\":\"alter_topic_configs\",\"arguments\":{\"topic\":\"events\"," +
+            "\"configs\":{\"cleanup.policy\":\"delete\"}},\"_meta\":{\"progressToken\":1}}");
+
+        assertEquals(Status.COMPLETED, status);
+        assertEquals("events", source.name());
+    }
+
+    @Test
     public void shouldResetBetweenCalls()
     {
         McpKafkaToolAlterConfigsSource source =

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolCreateAclsSourceTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolCreateAclsSourceTest.java
@@ -118,6 +118,20 @@ public class McpKafkaToolCreateAclsSourceTest
     }
 
     @Test
+    public void shouldIgnoreMetaSiblingOfArguments()
+    {
+        McpKafkaToolCreateAclsSource source = new McpKafkaToolCreateAclsSource();
+
+        Status status = parse(source,
+            "{\"name\":\"create_acls\",\"arguments\":{\"acls\":[{\"resource_type\":\"topic\"," +
+            "\"resource_name\":\"events\",\"principal\":\"User:alice\",\"operation\":\"read\"," +
+            "\"permission_type\":\"allow\"}]},\"_meta\":{\"progressToken\":1}}");
+
+        assertEquals(Status.COMPLETED, status);
+        assertEquals(1, source.creationCount());
+    }
+
+    @Test
     public void shouldResetBetweenCalls()
     {
         McpKafkaToolCreateAclsSource source = new McpKafkaToolCreateAclsSource();

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolCreateTopicsSourceTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolCreateTopicsSourceTest.java
@@ -19,87 +19,80 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 
-import io.aklivity.zilla.runtime.binding.kafka.api.KafkaDescribeConfigsRequest;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaCreateTopicsRequest.Source.Topic;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 
-public class McpKafkaToolDescribeConfigsSourceTest
+public class McpKafkaToolCreateTopicsSourceTest
 {
     @Test
-    public void shouldParseTopicResource()
+    public void shouldParseSingleTopic()
     {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC);
+        McpKafkaToolCreateTopicsSource source = new McpKafkaToolCreateTopicsSource(30000);
 
-        Status status = parse(source, "{\"arguments\":{\"topic\":\"events\"}}");
+        Status status = parse(source,
+            "{\"arguments\":{\"topics\":[{\"topic\":\"events\",\"partitions\":1,\"replicas\":1}]}}");
 
         assertEquals(Status.COMPLETED, status);
         assertTrue(source.completed());
-        assertEquals(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC, source.type());
-        assertEquals("events", source.name());
-        assertEquals(KafkaDescribeConfigsRequest.ALL_CONFIGS, source.configCount());
+        assertEquals(1, source.topicCount());
+
+        List<Topic> topics = new ArrayList<>();
+        source.forEach(topics::add);
+        Topic topic = topics.get(0);
+        assertEquals("events", topic.name());
+        assertEquals(1, topic.partitions());
+        assertEquals(1, topic.replicas());
     }
 
     @Test
-    public void shouldParseBrokerResource()
+    public void shouldIgnoreMetaSiblingOfArguments()
     {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_BROKER);
+        McpKafkaToolCreateTopicsSource source = new McpKafkaToolCreateTopicsSource(30000);
 
-        Status status = parse(source, "{\"arguments\":{\"broker_id\":0}}");
+        Status status = parse(source,
+            "{\"name\":\"create_topics\",\"arguments\":{\"topics\":[{\"topic\":\"events\"," +
+            "\"partitions\":1,\"replicas\":1}]},\"_meta\":{\"progressToken\":1}}");
 
         assertEquals(Status.COMPLETED, status);
-        assertEquals(KafkaDescribeConfigsRequest.RESOURCE_TYPE_BROKER, source.type());
-        assertEquals("0", source.name());
+        assertEquals(1, source.topicCount());
     }
 
     @Test
-    public void shouldRejectMissingResourceName()
+    public void shouldRejectEmptyTopicsArray()
     {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC);
+        McpKafkaToolCreateTopicsSource source = new McpKafkaToolCreateTopicsSource(30000);
 
-        Status status = parse(source, "{\"arguments\":{}}");
+        Status status = parse(source, "{\"arguments\":{\"topics\":[]}}");
 
         assertEquals(Status.REJECTED, status);
         assertFalse(source.completed());
     }
 
     @Test
-    public void shouldIgnoreMetaSiblingOfArguments()
-    {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC);
-
-        Status status = parse(source,
-            "{\"name\":\"describe_topic_configs\",\"arguments\":{\"topic\":\"events\"}," +
-            "\"_meta\":{\"progressToken\":1}}");
-
-        assertEquals(Status.COMPLETED, status);
-        assertEquals("events", source.name());
-    }
-
-    @Test
     public void shouldResetBetweenCalls()
     {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC);
+        McpKafkaToolCreateTopicsSource source = new McpKafkaToolCreateTopicsSource(30000);
 
-        parse(source, "{\"arguments\":{\"topic\":\"events\"}}");
+        parse(source, "{\"arguments\":{\"topics\":[{\"topic\":\"events\",\"partitions\":1,\"replicas\":1}]}}");
         assertTrue(source.completed());
 
         source.reset();
 
         assertFalse(source.completed());
+        assertEquals(0, source.topicCount());
     }
 
     private static Status parse(
-        McpKafkaToolDescribeConfigsSource source,
+        McpKafkaToolCreateTopicsSource source,
         String json)
     {
         final JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(source);

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDeleteAclsSourceTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDeleteAclsSourceTest.java
@@ -102,6 +102,19 @@ public class McpKafkaToolDeleteAclsSourceTest
     }
 
     @Test
+    public void shouldIgnoreMetaSiblingOfArguments()
+    {
+        McpKafkaToolDeleteAclsSource source = new McpKafkaToolDeleteAclsSource();
+
+        Status status = parse(source,
+            "{\"name\":\"delete_acls\",\"arguments\":{\"acls\":[{\"resource_type\":\"topic\"}]}," +
+            "\"_meta\":{\"progressToken\":1}}");
+
+        assertEquals(Status.COMPLETED, status);
+        assertEquals(1, source.filterCount());
+    }
+
+    @Test
     public void shouldResetBetweenCalls()
     {
         McpKafkaToolDeleteAclsSource source = new McpKafkaToolDeleteAclsSource();

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDeleteTopicsSourceTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDeleteTopicsSourceTest.java
@@ -19,87 +19,76 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 
-import io.aklivity.zilla.runtime.binding.kafka.api.KafkaDescribeConfigsRequest;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 
-public class McpKafkaToolDescribeConfigsSourceTest
+public class McpKafkaToolDeleteTopicsSourceTest
 {
     @Test
-    public void shouldParseTopicResource()
+    public void shouldParseTopics()
     {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC);
+        McpKafkaToolDeleteTopicsSource source = new McpKafkaToolDeleteTopicsSource(30000);
 
-        Status status = parse(source, "{\"arguments\":{\"topic\":\"events\"}}");
+        Status status = parse(source, "{\"arguments\":{\"topics\":[\"events\",\"snapshots\"]}}");
 
         assertEquals(Status.COMPLETED, status);
         assertTrue(source.completed());
-        assertEquals(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC, source.type());
-        assertEquals("events", source.name());
-        assertEquals(KafkaDescribeConfigsRequest.ALL_CONFIGS, source.configCount());
+        assertEquals(2, source.topicCount());
+
+        List<String> topics = new ArrayList<>();
+        source.forEach(topics::add);
+        assertEquals("events", topics.get(0));
+        assertEquals("snapshots", topics.get(1));
     }
 
     @Test
-    public void shouldParseBrokerResource()
+    public void shouldIgnoreMetaSiblingOfArguments()
     {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_BROKER);
+        McpKafkaToolDeleteTopicsSource source = new McpKafkaToolDeleteTopicsSource(30000);
 
-        Status status = parse(source, "{\"arguments\":{\"broker_id\":0}}");
+        Status status = parse(source,
+            "{\"name\":\"delete_topics\",\"arguments\":{\"topics\":[\"events\"]}," +
+            "\"_meta\":{\"progressToken\":1}}");
 
         assertEquals(Status.COMPLETED, status);
-        assertEquals(KafkaDescribeConfigsRequest.RESOURCE_TYPE_BROKER, source.type());
-        assertEquals("0", source.name());
+        assertEquals(1, source.topicCount());
     }
 
     @Test
-    public void shouldRejectMissingResourceName()
+    public void shouldRejectEmptyTopicsArray()
     {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC);
+        McpKafkaToolDeleteTopicsSource source = new McpKafkaToolDeleteTopicsSource(30000);
 
-        Status status = parse(source, "{\"arguments\":{}}");
+        Status status = parse(source, "{\"arguments\":{\"topics\":[]}}");
 
         assertEquals(Status.REJECTED, status);
         assertFalse(source.completed());
     }
 
     @Test
-    public void shouldIgnoreMetaSiblingOfArguments()
-    {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC);
-
-        Status status = parse(source,
-            "{\"name\":\"describe_topic_configs\",\"arguments\":{\"topic\":\"events\"}," +
-            "\"_meta\":{\"progressToken\":1}}");
-
-        assertEquals(Status.COMPLETED, status);
-        assertEquals("events", source.name());
-    }
-
-    @Test
     public void shouldResetBetweenCalls()
     {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC);
+        McpKafkaToolDeleteTopicsSource source = new McpKafkaToolDeleteTopicsSource(30000);
 
-        parse(source, "{\"arguments\":{\"topic\":\"events\"}}");
+        parse(source, "{\"arguments\":{\"topics\":[\"events\"]}}");
         assertTrue(source.completed());
 
         source.reset();
 
         assertFalse(source.completed());
+        assertEquals(0, source.topicCount());
     }
 
     private static Status parse(
-        McpKafkaToolDescribeConfigsSource source,
+        McpKafkaToolDeleteTopicsSource source,
         String json)
     {
         final JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(source);

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDescribeTopicSourceTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolDescribeTopicSourceTest.java
@@ -19,50 +19,40 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 
-import io.aklivity.zilla.runtime.binding.kafka.api.KafkaDescribeConfigsRequest;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 
-public class McpKafkaToolDescribeConfigsSourceTest
+public class McpKafkaToolDescribeTopicSourceTest
 {
     @Test
-    public void shouldParseTopicResource()
+    public void shouldParseTopic()
     {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC);
+        McpKafkaToolDescribeTopicSource source = new McpKafkaToolDescribeTopicSource();
 
         Status status = parse(source, "{\"arguments\":{\"topic\":\"events\"}}");
 
         assertEquals(Status.COMPLETED, status);
         assertTrue(source.completed());
-        assertEquals(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC, source.type());
-        assertEquals("events", source.name());
-        assertEquals(KafkaDescribeConfigsRequest.ALL_CONFIGS, source.configCount());
+        assertFalse(source.allTopics());
+        assertEquals(1, source.topicCount());
+
+        List<String> topics = new ArrayList<>();
+        source.forEach(topics::add);
+        assertEquals("events", topics.get(0));
     }
 
     @Test
-    public void shouldParseBrokerResource()
+    public void shouldRejectMissingTopic()
     {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_BROKER);
-
-        Status status = parse(source, "{\"arguments\":{\"broker_id\":0}}");
-
-        assertEquals(Status.COMPLETED, status);
-        assertEquals(KafkaDescribeConfigsRequest.RESOURCE_TYPE_BROKER, source.type());
-        assertEquals("0", source.name());
-    }
-
-    @Test
-    public void shouldRejectMissingResourceName()
-    {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC);
+        McpKafkaToolDescribeTopicSource source = new McpKafkaToolDescribeTopicSource();
 
         Status status = parse(source, "{\"arguments\":{}}");
 
@@ -73,22 +63,20 @@ public class McpKafkaToolDescribeConfigsSourceTest
     @Test
     public void shouldIgnoreMetaSiblingOfArguments()
     {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC);
+        McpKafkaToolDescribeTopicSource source = new McpKafkaToolDescribeTopicSource();
 
         Status status = parse(source,
-            "{\"name\":\"describe_topic_configs\",\"arguments\":{\"topic\":\"events\"}," +
+            "{\"name\":\"describe_topic\",\"arguments\":{\"topic\":\"events\"}," +
             "\"_meta\":{\"progressToken\":1}}");
 
         assertEquals(Status.COMPLETED, status);
-        assertEquals("events", source.name());
+        assertEquals(1, source.topicCount());
     }
 
     @Test
     public void shouldResetBetweenCalls()
     {
-        McpKafkaToolDescribeConfigsSource source =
-            new McpKafkaToolDescribeConfigsSource(KafkaDescribeConfigsRequest.RESOURCE_TYPE_TOPIC);
+        McpKafkaToolDescribeTopicSource source = new McpKafkaToolDescribeTopicSource();
 
         parse(source, "{\"arguments\":{\"topic\":\"events\"}}");
         assertTrue(source.completed());
@@ -96,10 +84,11 @@ public class McpKafkaToolDescribeConfigsSourceTest
         source.reset();
 
         assertFalse(source.completed());
+        assertEquals(0, source.topicCount());
     }
 
     private static Status parse(
-        McpKafkaToolDescribeConfigsSource source,
+        McpKafkaToolDescribeTopicSource source,
         String json)
     {
         final JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser()).into(source);

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolListAclsSourceTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaToolListAclsSourceTest.java
@@ -69,6 +69,20 @@ public class McpKafkaToolListAclsSourceTest
     }
 
     @Test
+    public void shouldIgnoreMetaSiblingOfArguments()
+    {
+        McpKafkaToolListAclsSource source = new McpKafkaToolListAclsSource();
+
+        Status status = parse(source,
+            "{\"name\":\"list_acls\",\"arguments\":{\"resource_type\":\"topic\"}," +
+            "\"_meta\":{\"progressToken\":1}}");
+
+        assertEquals(Status.COMPLETED, status);
+        assertTrue(source.completed());
+        assertEquals(KafkaAclTypes.RESOURCE_TYPE_TOPIC, source.resourceType());
+    }
+
+    @Test
     public void shouldResetBetweenCalls()
     {
         McpKafkaToolListAclsSource source = new McpKafkaToolListAclsSource();


### PR DESCRIPTION
## Description

Every `*Source` JSON transform class in `runtime/binding-mcp-kafka` (`McpKafkaToolListAclsSource`, `CreateAclsSource`, `DeleteAclsSource`, `AllTopicsSource`, `DescribeTopicSource`, `CreateTopicsSource`, `DeleteTopicsSource`, `AlterConfigsSource`, `DescribeConfigsSource`) pushed a literal `null` `Context` onto its `ArrayDeque<Context> stack` whenever a `START_OBJECT`/`START_ARRAY` event didn't match a known key/parent combination. `ArrayDeque` forbids null elements, so any unrecognized nested JSON structure threw `NullPointerException`, which propagated up through `AgentTerminationException` and killed the whole `EngineWorker` (`ENGINE_STOPPED`).

The `mcp` server binding forwards the raw JSON-RPC `tools/call` `params` object downstream, not just the `arguments` field in isolation. Per the MCP spec, clients commonly attach a `_meta` object (e.g. a progress token) alongside `name`/`arguments` on that object — every parser here crashed as soon as it reached `_meta`'s opening brace, since it isn't `"arguments"`.

The fix adds a non-null `IGNORED` context to each affected class's `Context` enum, and pushes that instead of `null` for any unrecognized object/array. `IGNORED` self-recurses for arbitrarily deep unrecognized nesting, so it can't desync the stack or corrupt parsing of the fields the class does recognize.

Regression tests reproduce the exact `_meta`-sibling-of-`arguments` shape for all nine classes; four of them (`AllTopicsSource`, `DescribeTopicSource`, `CreateTopicsSource`, `DeleteTopicsSource`) had no unit test coverage at all before this change, so new test files were added for them alongside the regression case.

Fixes a production crash reported against `zilla.yaml` configurations using the `mcp`/`mcp-kafka` bindings when driven by Claude Code's MCP client.

## Test plan

- [x] `McpKafkaTool*SourceTest` unit tests added/updated to reproduce the crash and assert it no longer occurs
- [ ] `./mvnw install -pl runtime/binding-mcp-kafka` (full module build + tests)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MkHCoHvERvXq47FZM7T3G

---
_Generated by [Claude Code](https://claude.ai/code/session_017MkHCoHvERvXq47FZM7T3G)_