### PR TITLE
build: move NOTICE check to verify phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
           </configuration>
           <executions>
             <execution>
-              <phase>validate</phase>
+              <phase>verify</phase>
               <goals>
                 <goal>check</goal>
               </goals>


### PR DESCRIPTION
## Description

The `maven-notice-plugin` check (goal `check`) was bound to the `validate` phase — the very first phase of the default Maven lifecycle, ahead of `compile`. This meant any local iteration on a single module (`mvn compile`, `mvn test`) would fail on a stale NOTICE file before reaching compilation or test execution at all, even when the goal at hand had nothing to do with dependency attribution.

This PR rebinds the check to the `verify` phase instead. Since every module's `pom.xml` declares the plugin bare and inherits the execution binding from the root `pom.xml`'s `pluginManagement`, this is a single-line change with no other files to touch. `mvn verify` / `mvn install` (already the commands required before opening a PR) still enforce the check exactly as before; `mvn compile` / `mvn test` no longer trip over it.

No dependencies are required for this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bfbZJZz7o45q4S1mikU1A

---
_Generated by [Claude Code](https://claude.ai/code/session_014bfbZJZz7o45q4S1mikU1A)_