### PR TITLE
ci: cache maven wrapper distribution to avoid per-build downloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,12 @@ jobs:
           !~/.m2/repository/io/aklivity/zilla
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+    - name: Cache Maven wrapper distribution
+      uses: actions/cache@v6
+      with:
+        path: ~/.m2/wrapper
+        key: ${{ runner.os }}-m2-wrapper-${{ hashFiles('**/maven-wrapper.properties') }}
+        restore-keys: ${{ runner.os }}-m2-wrapper-
     - name: Cache ZPM test artifacts
       uses: actions/cache@v6
       with:


### PR DESCRIPTION
## Description

The Maven wrapper jar and the Maven distribution zip it fetches (`apache-maven-3.9.14-bin.zip`) land under `~/.m2/wrapper`, a sibling directory of `~/.m2/repository`. The existing `Cache Maven packages` step in `build.yml` only caches `~/.m2/repository`, so every build re-downloaded the wrapper jar and the ~10MB Maven distribution zip from Maven Central, even on a full dependency-cache hit.

This adds a dedicated cache step for `~/.m2/wrapper`, keyed on `hashFiles('**/maven-wrapper.properties')` so a wrapper-version bump invalidates only this small cache rather than the larger dependency cache.

Note: `release.yml` already caches the whole `~/.m2` directory and was unaffected by this gap; this change brings `build.yml` in line with it.

---
_Generated by [Claude Code](https://claude.ai/code/session_011d1LPWiNeTmi5johUb4ntn)_