### PR TITLE
fix(binding-mcp): return HTTP 404 for unknown/expired MCP session

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
@@ -84,7 +84,7 @@ public class McpConfiguration extends Configuration
         MCP_CLIENT_VERSION = config.property(String.class, "client.version", (c, v) -> v,
             McpConfiguration::defaultServerVersion);
         MCP_INACTIVITY_TIMEOUT = config.property(Duration.class, "inactivity.timeout",
-            (c, v) -> Duration.parse(v), "PT60S");
+            (c, v) -> Duration.parse(v), "PT300S");
         MCP_KEEPALIVE_TOLERANCE = config.property("keepalive.tolerance", 2);
         MCP_SSE_KEEPALIVE_INTERVAL = config.property(Duration.class, "sse.keepalive.interval",
             (c, v) -> Duration.parse(v), "PT15S");

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -130,6 +130,7 @@ public final class McpServerFactory implements McpStreamFactory
     private static final String STATUS_400 = "400";
     private static final String STATUS_401 = "401";
     private static final String STATUS_403 = "403";
+    private static final String STATUS_404 = "404";
     private static final String STATUS_405 = "405";
     private static final String STATUS_406 = "406";
     private static final String STATUS_410 = "410";
@@ -478,7 +479,7 @@ public final class McpServerFactory implements McpStreamFactory
             case "DELETE":
                 if (session == null)
                 {
-                    newStream = new McpRejectHandler(sender, STATUS_400)::onNetBegin;
+                    newStream = new McpRejectHandler(sender, STATUS_404)::onNetBegin;
                 }
                 else
                 {
@@ -541,7 +542,7 @@ public final class McpServerFactory implements McpStreamFactory
         else if (session == null)
         {
             deauthorize.run();
-            newStream = new McpRejectHandler(sender, STATUS_400)::onNetBegin;
+            newStream = new McpRejectHandler(sender, STATUS_404)::onNetBegin;
         }
         else if (session.eventsUnsupported)
         {
@@ -1008,7 +1009,7 @@ public final class McpServerFactory implements McpStreamFactory
             {
                 if (server.session == null)
                 {
-                    server.onDecodeInvalidRequest(traceId, authorization);
+                    server.onDecodeSessionNotFound(traceId, authorization);
                     server.decoder = decodeIgnore;
                     break decode;
                 }
@@ -2552,6 +2553,19 @@ public final class McpServerFactory implements McpStreamFactory
                     .build(),
                 -32600,
                 "Invalid request");
+        }
+
+        private void onDecodeSessionNotFound(
+            long traceId,
+            long authorization)
+        {
+            doNetBegin(traceId, authorization,
+                httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                    .typeId(httpTypeId)
+                    .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_404))
+                    .inject(this::injectAltSvc)
+                    .build());
+            doNetEnd(traceId, authorization);
         }
 
         private void onDecodeMethodNotFound(

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfigurationTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfigurationTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
+import java.time.Duration;
 import java.util.UUID;
 import java.util.function.LongFunction;
 
@@ -84,6 +85,14 @@ public class McpConfigurationTest
         assertEquals(MCP_HYDRATE_FILTER.name(), MCP_HYDRATE_FILTER_NAME);
         assertEquals(MCP_LEASE_TTL.name(), MCP_LEASE_TTL_NAME);
         assertEquals(MCP_LEASE_RETRY.name(), MCP_LEASE_RETRY_NAME);
+    }
+
+    @Test
+    public void shouldDefaultInactivityTimeoutToFiveMinutes()
+    {
+        McpConfiguration config = new McpConfiguration();
+
+        assertEquals(Duration.ofMinutes(5), config.inactivityTimeout());
     }
 
     @Test

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -872,6 +872,24 @@ public class McpServerIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/reject.request.session.unknown/client"})
+    public void shouldRejectRequestSessionUnknown() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
+        "${net}/reject.request.session.missing/client"})
+    public void shouldRejectRequestSessionMissing() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/lifecycle.initialize.reject.capabilities.invalid/client"})
     public void shouldRejectLifecycleInitializeCapabilitiesInvalid() throws Exception
     {

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.session.missing/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.session.missing/client.rpt
@@ -1,0 +1,41 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "404")
+                           .build()}
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.session.missing/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.session.missing/server.rpt
@@ -1,0 +1,42 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "404")
+                            .build()}
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.session.unknown/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.session.unknown/client.rpt
@@ -1,0 +1,42 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-session-id", "5ca1ab1e-c0de-4a11-1057-000000000000")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "404")
+                           .build()}
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.session.unknown/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.session.unknown/server.rpt
@@ -1,0 +1,43 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "5ca1ab1e-c0de-4a11-1057-000000000000")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "404")
+                            .build()}
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -254,6 +254,24 @@ public class NetworkIT
 
     @Test
     @Specification({
+        "${net}/reject.request.session.unknown/client",
+        "${net}/reject.request.session.unknown/server"})
+    public void shouldRejectRequestSessionUnknown() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${net}/reject.request.session.missing/client",
+        "${net}/reject.request.session.missing/server"})
+    public void shouldRejectRequestSessionMissing() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/lifecycle.initialize.reject.capabilities.invalid/client",
         "${net}/lifecycle.initialize.reject.capabilities.invalid/server"})
     public void shouldRejectLifecycleInitializeCapabilitiesInvalid() throws Exception


### PR DESCRIPTION
## Description

Per the MCP Streamable HTTP transport spec, a server should respond to a request bearing a terminated/unknown `Mcp-Session-Id` with HTTP 404, which is the client's signal to discard the session and silently reinitialize. `McpServerFactory` never returned a 404 for this case:

- GET (SSE reconnect) and DELETE (shutdown) with an unknown/missing session returned HTTP 400.
- POST (e.g. `tools/call`) with an unknown/missing session returned HTTP 200 wrapping a JSON-RPC `-32600 "Invalid Request"` error, giving spec-compliant clients no reliable signal to recover.

This PR:
- Adds a `STATUS_404` constant and switches the GET/DELETE "session not found" rejection path from 400 to 404.
- Adds a new `onDecodeSessionNotFound` response path for POST so an unknown/missing session returns a bare HTTP 404 (mirroring the existing `doNetBeginRejectedBearer` no-body-response pattern) instead of a 200 with a JSON-RPC error body.
- Adds two new k3po scenarios (`reject.request.session.unknown`, `reject.request.session.missing`) plus matching `McpServerIT` tests asserting the POST 404.

Also raises the default `zilla.binding.mcp.inactivity.timeout` from `PT60S` to `PT300S`. 60s is easy to exceed during ordinary interactive use (e.g. an LLM agent client with think-time between tool calls), tearing down sessions the client still considers active. Added a `McpConfigurationTest` case asserting the new default; the one existing IT that exercises timeout behavior already overrides the value explicitly via `@Configure`, so it's unaffected.

Fixes #2525

## Test plan

- [x] `./mvnw clean install` at the repo root (full reactor, all modules) — green except `cloud/docker-image`, which failed on a transient Docker Hub anonymous-pull rate limit (`429`) fetching the base JDK image, unrelated to this change (that module only packages already-built/tested jars into a container image, no code involved)
- [x] `runtime/binding-mcp`'s `McpServerIT`: 100/100 tests passing, including the two new session-not-found 404 tests
- [x] `runtime/binding-mcp`'s `McpConfigurationTest`: 9/9 tests passing, including the new default-timeout assertion
- [x] `specs/binding-mcp.spec` builds clean with the new k3po scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3SSVuazBL9vG9FTVUmUKm

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3SSVuazBL9vG9FTVUmUKm)_