### PR TITLE
fix(binding-mcp): honor south exits' real capabilities in route resolution

### DIFF
--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfig.java
@@ -14,6 +14,8 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.http.internal.config;
 
+import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.McpCapabilities.SERVER_RESOURCES;
+import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.McpCapabilities.SERVER_TOOLS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
@@ -232,6 +234,24 @@ public final class McpHttpBindingConfig
     public Collection<McpHttpResourceConfig> resources()
     {
         return resourcesByName.values();
+    }
+
+    // real, declared capabilities -- this binding is configured with whichever of tools/resources
+    // its own routes actually resolve to (McpOpenapiCompositeGenerator only ever emits one or the
+    // other, or both), never prompts, so this reflects real config rather than echoing back
+    // whatever a connecting north forwarded for its own client's elicitation support
+    public int serverCapabilities()
+    {
+        int bits = 0;
+        if (!toolsByName.isEmpty())
+        {
+            bits |= SERVER_TOOLS.value();
+        }
+        if (!resourcesByName.isEmpty())
+        {
+            bits |= SERVER_RESOURCES.value();
+        }
+        return bits;
     }
 
     public byte[] toolsListJson()

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
@@ -232,9 +232,8 @@ public final class McpHttpProxyFactory implements BindingHandler
 
             if (kind == KIND_LIFECYCLE)
             {
-                final int capabilities = beginEx.lifecycle().capabilities();
                 final String sessionId = newSessionId();
-                newStream = new McpSession(sessionId, capabilities,
+                newStream = new McpSession(sessionId, binding.serverCapabilities(),
                     sender, originId, routedId, initialId, authorization, affinity)::onMcpMessage;
             }
             else
@@ -2279,6 +2278,9 @@ public final class McpHttpProxyFactory implements BindingHandler
         {
             if (!McpHttpState.replyOpened(state))
             {
+                // capabilities is this binding's own declared real capabilities (McpHttpBindingConfig.
+                // serverCapabilities, computed from its configured tools/resources), not an echo of
+                // whatever the connecting north forwarded for its own client's elicitation support
                 final McpBeginExFW lifecycleEx = mcpBeginExRW.wrap(extBuffer, 0, extBuffer.capacity())
                     .typeId(mcpTypeId)
                     .lifecycle(l -> l

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfigTest.java
@@ -15,6 +15,8 @@
 package io.aklivity.zilla.runtime.binding.mcp.http.internal.config;
 
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.config.McpHttpBindingConfig.argPathValid;
+import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.McpCapabilities.SERVER_RESOURCES;
+import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.McpCapabilities.SERVER_TOOLS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -29,6 +31,9 @@ import java.util.List;
 import org.junit.Test;
 
 import io.aklivity.zilla.config.binding.mcp.http.McpHttpConditionConfig;
+import io.aklivity.zilla.config.binding.mcp.http.McpHttpOptionsConfig;
+import io.aklivity.zilla.config.binding.mcp.http.McpHttpResourceConfig;
+import io.aklivity.zilla.config.binding.mcp.http.McpHttpToolConfig;
 import io.aklivity.zilla.config.binding.mcp.http.McpHttpWithConfig;
 import io.aklivity.zilla.config.engine.BindingConfig;
 import io.aklivity.zilla.config.engine.GenericBindingConfig;
@@ -74,6 +79,20 @@ public class McpHttpBindingConfigTest
             .type("mcp-http")
             .kind(KindConfig.PROXY)
             .routes(routes)
+            .build();
+        return new McpHttpBindingConfig(config, null, "sys:http_client");
+    }
+
+    private static McpHttpBindingConfig bindingWithOptions(
+        McpHttpOptionsConfig options)
+    {
+        BindingConfig config = GenericBindingConfig.builder()
+            .namespace("test")
+            .name("app0")
+            .type("mcp-http")
+            .kind(KindConfig.PROXY)
+            .options(options)
+            .routes(List.of())
             .build();
         return new McpHttpBindingConfig(config, null, "sys:http_client");
     }
@@ -310,5 +329,47 @@ public class McpHttpBindingConfigTest
     public void shouldAcceptWhenSchemaMalformed()
     {
         assertTrue(argPathValid("{ not json", "owner"));
+    }
+
+    @Test
+    public void shouldDeclareToolsCapabilityWhenOnlyToolsConfigured()
+    {
+        McpHttpOptionsConfig options = McpHttpOptionsConfig.builder()
+            .tools(List.of(McpHttpToolConfig.builder().name("create_pr").build()))
+            .build();
+        McpHttpBindingConfig binding = bindingWithOptions(options);
+
+        assertThat(binding.serverCapabilities(), equalTo(SERVER_TOOLS.value()));
+    }
+
+    @Test
+    public void shouldDeclareResourcesCapabilityWhenOnlyResourcesConfigured()
+    {
+        McpHttpOptionsConfig options = McpHttpOptionsConfig.builder()
+            .resources(List.of(McpHttpResourceConfig.builder().name("order").uri("/orders/{id}").build()))
+            .build();
+        McpHttpBindingConfig binding = bindingWithOptions(options);
+
+        assertThat(binding.serverCapabilities(), equalTo(SERVER_RESOURCES.value()));
+    }
+
+    @Test
+    public void shouldDeclareBothCapabilitiesWhenToolsAndResourcesConfigured()
+    {
+        McpHttpOptionsConfig options = McpHttpOptionsConfig.builder()
+            .tools(List.of(McpHttpToolConfig.builder().name("create_pr").build()))
+            .resources(List.of(McpHttpResourceConfig.builder().name("order").uri("/orders/{id}").build()))
+            .build();
+        McpHttpBindingConfig binding = bindingWithOptions(options);
+
+        assertThat(binding.serverCapabilities(), equalTo(SERVER_TOOLS.value() | SERVER_RESOURCES.value()));
+    }
+
+    @Test
+    public void shouldDeclareNoCapabilitiesWhenNeitherToolsNorResourcesConfigured()
+    {
+        McpHttpBindingConfig binding = binding(List.of());
+
+        assertThat(binding.serverCapabilities(), equalTo(0));
     }
 }

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactory.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactory.java
@@ -468,9 +468,8 @@ public class McpKafkaProxyFactory implements BindingHandler
                 {
                 case KIND_LIFECYCLE:
                 {
-                    final int capabilities = mcpBeginEx.lifecycle().capabilities();
                     final McpLifecycleProxy lifecycle = new McpLifecycleProxy(
-                        sender, originId, routedId, initialId, authorization, affinity, capabilities);
+                        sender, originId, routedId, initialId, authorization, affinity);
                     newStream = lifecycle::onMcpMessage;
                     break;
                 }
@@ -2083,7 +2082,6 @@ public class McpKafkaProxyFactory implements BindingHandler
         private final long replyId;
         private final long authorization;
         private final long affinity;
-        private final int capabilities;
 
         private int state;
 
@@ -2093,8 +2091,7 @@ public class McpKafkaProxyFactory implements BindingHandler
             long routedId,
             long initialId,
             long authorization,
-            long affinity,
-            int capabilities)
+            long affinity)
         {
             this.mcp = mcp;
             this.originId = originId;
@@ -2103,7 +2100,6 @@ public class McpKafkaProxyFactory implements BindingHandler
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.authorization = authorization;
             this.affinity = affinity;
-            this.capabilities = capabilities;
         }
 
         private void onMcpMessage(
@@ -2166,11 +2162,14 @@ public class McpKafkaProxyFactory implements BindingHandler
             long traceId)
         {
             final String sessionId = supplySessionId.get();
+            // this binding type is tools-only by construction (its route condition schema
+            // rejects prompt:/resource: selectors), so it always declares CAPABILITIES_TOOLS
+            // here rather than echoing whatever capabilities the connecting north forwarded
             final McpBeginExFW lifecycleEx = mcpBeginExRW.wrap(extBuffer, 0, extBuffer.capacity())
                 .typeId(mcpTypeId)
                 .lifecycle(l -> l
                     .sessionId(sessionId)
-                    .capabilities(capabilities != 0 ? capabilities : CAPABILITIES_TOOLS))
+                    .capabilities(CAPABILITIES_TOOLS))
                 .build();
 
             doBegin(mcp, originId, routedId, replyId, traceId, authorization, affinity, lifecycleEx);

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactoryTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactoryTest.java
@@ -44,6 +44,7 @@ import io.aklivity.zilla.config.engine.KindConfig;
 import io.aklivity.zilla.config.engine.RouteConfig;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.McpKafkaConfiguration;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.KafkaOffsetFW;
+import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.McpCapabilities;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.AbortFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.BeginFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.DataFW;
@@ -92,6 +93,7 @@ public class McpKafkaProxyFactoryTest
     private final EndFW endRO = new EndFW();
     private final ResetFW resetRO = new ResetFW();
     private final KafkaBeginExFW kafkaBeginExRO = new KafkaBeginExFW();
+    private final McpBeginExFW mcpBeginExRO = new McpBeginExFW();
     private final McpResetExFW mcpResetExRO = new McpResetExFW();
     private final McpEndExFW mcpEndExRO = new McpEndExFW();
 
@@ -193,6 +195,38 @@ public class McpKafkaProxyFactoryTest
                 .name(tool)
                 .contentLength(contentLength)
                 .timeout(timeout))
+            .build();
+
+        final BeginFW begin = beginRW.wrap(scratch, 0, scratch.capacity())
+            .originId(ORIGIN_ID)
+            .routedId(BINDING_ID)
+            .streamId(INITIAL_ID)
+            .sequence(0)
+            .acknowledge(0)
+            .maximum(0)
+            .traceId(1L)
+            .authorization(AUTHORIZATION)
+            .affinity(AFFINITY)
+            .extension(beginEx.buffer(), beginEx.offset(), beginEx.sizeof())
+            .build();
+
+        final MessageConsumer stream = factory.newStream(
+            begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof(), mcp);
+
+        if (stream != null)
+        {
+            stream.accept(begin.typeId(), begin.buffer(), begin.offset(), begin.sizeof());
+        }
+
+        return stream;
+    }
+
+    private MessageConsumer beginLifecycle(
+        int capabilities)
+    {
+        final McpBeginExFW beginEx = mcpBeginExRW.wrap(extScratch, 0, extScratch.capacity())
+            .typeId(MCP_TYPE_ID)
+            .lifecycle(l -> l.capabilities(capabilities))
             .build();
 
         final BeginFW begin = beginRW.wrap(scratch, 0, scratch.capacity())
@@ -390,6 +424,15 @@ public class McpKafkaProxyFactoryTest
         final BeginFW begin = beginRO.wrap(buffer, 0, recorded.bytes.length);
 
         return kafkaBeginExRO.wrap(begin.extension().buffer(), begin.extension().offset(), begin.extension().limit());
+    }
+
+    private McpBeginExFW mcpBeginEx(
+        Recorded recorded)
+    {
+        final UnsafeBufferEx buffer = new UnsafeBufferEx(recorded.bytes);
+        final BeginFW begin = beginRO.wrap(buffer, 0, recorded.bytes.length);
+
+        return mcpBeginExRO.wrap(begin.extension().buffer(), begin.extension().offset(), begin.extension().limit());
     }
 
     private McpResetExFW mcpResetEx(
@@ -653,6 +696,28 @@ public class McpKafkaProxyFactoryTest
 
         assertNull(stream);
         assertEquals(0, countOf(kafkaSent, BeginFW.TYPE_ID));
+    }
+
+    @Test
+    public void shouldDeclareToolsOnlyCapabilitiesRegardlessOfClientCapabilities() throws Exception
+    {
+        factory.attach(newBinding("produce_message"));
+
+        beginLifecycle(McpCapabilities.CLIENT_ELICITATION.value());
+
+        final McpBeginExFW lifecycleEx = mcpBeginEx(nthOf(mcpSent, BeginFW.TYPE_ID, 1));
+        assertEquals(McpCapabilities.SERVER_TOOLS.value(), lifecycleEx.lifecycle().capabilities());
+    }
+
+    @Test
+    public void shouldDeclareToolsOnlyCapabilitiesWhenClientSendsNone() throws Exception
+    {
+        factory.attach(newBinding("produce_message"));
+
+        beginLifecycle(0);
+
+        final McpBeginExFW lifecycleEx = mcpBeginEx(nthOf(mcpSent, BeginFW.TYPE_ID, 1));
+        assertEquals(McpCapabilities.SERVER_TOOLS.value(), lifecycleEx.lifecycle().capabilities());
     }
 
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -42,6 +42,7 @@ import io.aklivity.zilla.config.engine.BindingConfig;
 import io.aklivity.zilla.config.engine.ModelConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache.McpProxyCache;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.String8FW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.HttpBeginExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBearerError;
@@ -71,6 +72,10 @@ public final class McpBindingConfig
     private static final String PATH_ROOT = "/";
 
     private static final Map<String, List<String>> EMPTY_ROLES = Map.of();
+
+    private static final int SERVER_CAPABILITIES_MASK = McpCapabilities.SERVER_TOOLS.value()
+        | McpCapabilities.SERVER_PROMPTS.value()
+        | McpCapabilities.SERVER_RESOURCES.value();
 
     public static final String CREDENTIALS_PLACEHOLDER = "{credentials}";
 
@@ -494,6 +499,28 @@ public final class McpBindingConfig
         }
     }
 
+    // a route's static when:-derived capability set (McpRouteConfig.serves) treats an
+    // unrestricted condition as serving every capability, regardless of what the south
+    // exit it routes to can actually serve. Once that south exit's own KIND_LIFECYCLE
+    // handshake has recorded its real capabilities, narrow the static set down to what
+    // south actually declared; before that handshake completes, realCapabilitiesByRoute
+    // holds no bits yet for this route and the static set is used as-is.
+    private boolean routeServes(
+        McpRouteConfig route,
+        String capability)
+    {
+        boolean serves = route.serves(capability);
+        if (serves)
+        {
+            final long realCapabilities = realCapabilitiesByRoute.get(route.id) & SERVER_CAPABILITIES_MASK;
+            if (realCapabilities != 0L)
+            {
+                serves = (realCapabilities & McpRouteConfig.capabilityBit(capability)) != 0L;
+            }
+        }
+        return serves;
+    }
+
     public McpRouteConfig resolve(
         McpBeginExFW beginEx,
         long authorization)
@@ -522,7 +549,7 @@ public final class McpBindingConfig
         {
             for (McpRouteConfig route : routes)
             {
-                if (route.authorized(authorization) && route.serves(capability))
+                if (route.authorized(authorization) && routeServes(route, capability))
                 {
                     resolved = route;
                     break;
@@ -611,7 +638,7 @@ public final class McpBindingConfig
             for (McpRouteConfig route : routes)
             {
                 final long authorization = routeCacheAuthorization(traceId, route.id);
-                if (route.authorized(authorization) && route.serves(capability))
+                if (route.authorized(authorization) && routeServes(route, capability))
                 {
                     result.add(new McpRoutePrefix(route.id, new String8FW(route.prefix(kind)), route));
                 }
@@ -634,7 +661,7 @@ public final class McpBindingConfig
         {
             for (McpRouteConfig route : routes)
             {
-                if (route.authorized(authorization) && route.serves(capability))
+                if (route.authorized(authorization) && routeServes(route, capability))
                 {
                     result.add(route);
                 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
@@ -279,6 +279,18 @@ public final class McpRouteConfig
         };
     }
 
+    static int capabilityBit(
+        String capability)
+    {
+        return switch (capability)
+        {
+        case CAPABILITY_TOOLS -> SERVER_TOOLS.value();
+        case CAPABILITY_PROMPTS -> SERVER_PROMPTS.value();
+        case CAPABILITY_RESOURCES -> SERVER_RESOURCES.value();
+        default -> 0;
+        };
+    }
+
     static String identifierOf(
         McpBeginExFW beginEx)
     {

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfigTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfigTest.java
@@ -19,6 +19,9 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingCo
 import static io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingConfig.naturalAuthority;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingConfig.pathOf;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingConfig.rolesForTool;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.SERVER_TOOLS;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -97,6 +100,21 @@ public class McpBindingConfigTest
         }
         RouteConfig config = builder.build();
         config.id = id;
+        return config;
+    }
+
+    private static RouteConfig unrestrictedRoute(
+        long id,
+        String toolkit)
+    {
+        RouteConfig config = RouteConfig.builder()
+            .exit("test")
+            .when(McpConditionConfig.builder()
+                .toolkit(toolkit)
+                .build())
+            .build();
+        config.id = id;
+        config.authorized = (authorization, credentials) -> true;
         return config;
     }
 
@@ -266,5 +284,35 @@ public class McpBindingConfigTest
         assertThat(authorization, equalTo(9L));
         verify(guard, times(1)).reauthorize(anyLong(), anyLong(), anyLong(), eq("{override}"));
         verify(guard, times(0)).reauthorize(anyLong(), anyLong(), anyLong(), eq("{shared}"));
+    }
+
+    @Test
+    public void shouldResolveUnrestrictedRouteForAnyCapabilityBeforeRealCapabilitiesRecorded()
+    {
+        GuardHandler guard = mock(GuardHandler.class);
+        RouteConfig route = unrestrictedRoute(300L, "alpha");
+        McpBindingConfig binding = binding(guard, null, List.of(route));
+
+        List<McpRoutePrefix> prompts = binding.resolveAll(0L, KIND_PROMPTS_LIST);
+
+        assertThat(prompts.size(), equalTo(1));
+        assertThat(prompts.get(0).resolvedId(), equalTo(300L));
+    }
+
+    @Test
+    public void shouldExcludeUnrestrictedRouteForCapabilityNotInRecordedRealCapabilities()
+    {
+        GuardHandler guard = mock(GuardHandler.class);
+        RouteConfig route = unrestrictedRoute(400L, "alpha");
+        McpBindingConfig binding = binding(guard, null, List.of(route));
+
+        binding.recordServerCapabilities(400L, SERVER_TOOLS.value());
+
+        List<McpRoutePrefix> prompts = binding.resolveAll(0L, KIND_PROMPTS_LIST);
+        List<McpRoutePrefix> tools = binding.resolveAll(0L, KIND_TOOLS_LIST);
+
+        assertThat(prompts, empty());
+        assertThat(tools.size(), equalTo(1));
+        assertThat(tools.get(0).resolvedId(), equalTo(400L));
     }
 }


### PR DESCRIPTION
## Description

`McpBindingConfig.resolve()`/`resolveAll()` — the shared route-resolution path used by both live request routing and `McpProxyCacheHydrater`'s cache hydration — decided whether a route serves a given capability (tools/prompts/resources) using only the route's static `when:` condition, never consulting `realCapabilitiesByRoute`, the mechanism that actually learns a south route's real, live capabilities from its own `KIND_LIFECYCLE` handshake. Since an unrestricted `when:` condition (e.g. selecting only on `toolkit:`) is treated as serving every capability, a route in front of a tools-only south exit (`mcp-kafka`) was still probed for prompts/resources, surfacing as continuous `BINDING_MCP_HYDRATE_FAILED ... ROUTE_FAILED` during cache hydration, plus the same gap in live request routing.

Tracing the two other binding types named in the issue (`mcp-kafka-connect`, `mcp-schema-registry`) further: both are pure byte-transparent relays into an internally-composited `mcp-openapi` binding, itself a transparent relay into a further-composited `mcp-http` binding — the actual `KIND_LIFECYCLE` handshake for all three terminates in `McpHttpProxyFactory`, which had the same bug in a more severe form (no fallback at all, unconditional echo).

### Changes

1. **`binding-mcp`** — `McpBindingConfig` now intersects a route's static capability set with its recorded real capabilities once that exit's lifecycle handshake has reported them, at both call sites sharing this resolution path: cache hydration (`resolveAll(traceId, kind)`) and live request routing (`resolve`/`resolveAll` on `McpBeginExFW`). Before that handshake completes, no real capabilities are recorded yet and the static set is used as-is, so this narrows an over-broad match rather than gating on wire timing.
2. **`binding-mcp-kafka`** — tools-only by construction (its route condition schema rejects `prompt:`/`resource:` selectors), so its `KIND_LIFECYCLE` reply now always declares `SERVER_TOOLS` instead of echoing back whatever capabilities bits the connecting north forwarded for its own client's elicitation support.
3. **`binding-mcp-http`** — not tools-only (`McpOpenapiCompositeGenerator` routes some OpenAPI operations to tools and others to resources depending on the spec), so a fixed constant would be wrong here. `McpHttpBindingConfig.serverCapabilities()` now computes real capabilities from what's actually configured (`SERVER_TOOLS` when `tools()` is non-empty, `SERVER_RESOURCES` when `resources()` is non-empty), and `McpHttpProxyFactory`'s lifecycle reply declares that instead of the client-forwarded value. This transitively fixes `mcp-kafka-connect` and `mcp-schema-registry` too (both only ever generate tool routes through the composite chain in practice), as well as `mcp-openapi`/`mcp-http` used directly with resource-only routes (confirmed schema-valid: neither binding's schema requires at least one tool route).

### Testing

- `McpBindingConfigTest`: unit tests proving a route with an unrestricted condition is excluded from `prompts` resolution once real capabilities are recorded as tools-only, and still included beforehand (before the lifecycle handshake completes).
- `McpKafkaProxyFactoryTest`: proves the lifecycle reply always declares tools-only regardless of what the client forwarded.
- `McpHttpBindingConfigTest`: proves `serverCapabilities()` returns the correct bits for tools-only, resources-only, both, and neither configured.

**Build verification caveat**: `./mvnw verify` could not be run in the sandbox this was authored in — `flyweight-maven-plugin` and other internal artifacts require resolving from `maven.packages.aklivity.io`, which redirects to an auth flow unavailable there. Changes were reviewed carefully by hand (types, imports, checkstyle conventions, generated-flyweight API shapes cross-checked against existing working code) but CI is the first real compile/checkstyle/test confirmation.

Fixes #2524

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Px3kTeX1XXiUpEk4pLwcjq)_