### PR TITLE
fix(examples): cache npm install for mcp.proxy's "everything" service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,6 +252,23 @@ jobs:
             docker load -i ~/docker-images-cache/images.tar || true
           fi
 
+      # mcp.proxy's "everything" toolkit is installed via a live `npx -y` at
+      # container start (no baked-in image), so the cold path -- npm resolving
+      # and fetching 100+ transitive packages one by one -- takes anywhere
+      # from ~2 to 5+ minutes depending on npm-registry conditions, observed
+      # to occasionally exceed even the healthcheck's generous 10-minute
+      # ceiling under a slow registry. Restoring npm's own cache directory
+      # (mounted into the container -- see compose.yaml's `everything`
+      # service) turns that into a few-seconds no-op fetch instead. Bump the
+      # key's version suffix if the pinned @modelcontextprotocol/server-everything
+      # version in that compose.yaml ever changes.
+      - name: Restore npm cache for shared MCP "everything" server
+        if: ${{ matrix.dir == 'mcp.proxy' }}
+        uses: actions/cache@v6
+        with:
+          path: examples/${{ matrix.dir }}/.cache/npm-everything
+          key: npm-everything-2026.7.4-${{ runner.os }}
+
       - name: Start Zilla and wait for it to be healthy
         working-directory: examples/${{ matrix.dir }}
         run: docker compose up -d --wait

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ hs_err_pid*.log
 *.tokens
 gen/
 examples/grpc-clicker.json
+.cache/
 .claude/
 AGENTS.override.md
 compose.override.yaml

--- a/examples/mcp.proxy/compose.yaml
+++ b/examples/mcp.proxy/compose.yaml
@@ -59,10 +59,22 @@ services:
     command: ["npx", "-y", "@modelcontextprotocol/server-everything@2026.7.4", "streamableHttp"]
     environment:
       PORT: "3001"
+    # Persists npm's download/extract cache across container recreations --
+    # CI restores/saves this same path via actions/cache, keyed on the pinned
+    # version above, turning the cold ~2-5 minute install into a few seconds
+    # on a cache hit. Gitignored; harmless if absent (falls back to a fresh,
+    # empty directory and pays the normal cold-install cost once).
+    volumes:
+      - ./.cache/npm-everything:/root/.npm
     healthcheck:
+      # A cold `npx -y` install of this package (no cache volume, so every
+      # container start re-fetches it) has been observed taking anywhere from
+      # ~2 to 5+ minutes depending on npm-registry conditions; retries is
+      # sized with a generous 10-minute ceiling rather than a tight bound on
+      # the slowest observed run.
       interval: 5s
       timeout: 3s
-      retries: 10
+      retries: 120
       start_period: 30s
       start_interval: 250ms
       test: ["CMD", "nc", "-z", "127.0.0.1", "3001"]


### PR DESCRIPTION
### Summary

The `mcp.proxy` example's `testing (mcp.proxy)` CI check has been failing on `develop` HEAD (independent of any other change — see [#2534](https://github.com/aklivity/zilla/pull/2534#issuecomment-5534714809) for the investigation that traced it here). The `everything` service installs the pinned `@modelcontextprotocol/server-everything@2026.7.4` via a live `npx -y` at every container start, with no baked-in image. That cold path — npm resolving and fetching 100+ transitive packages one by one — takes anywhere from ~2 to 5+ minutes depending on npm-registry conditions, occasionally exceeding the original healthcheck's tight ~80s budget (30s `start_period` + 10 × 5s `retries`) under registry latency or throttling. On `develop` this showed up as the container never reporting healthy, with an empty container log (the fetch was still in flight when CI collected logs on failure).

### Fix

Mount npm's own download/extract cache directory into the container (gitignored, harmless if absent) and restore/save it via `actions/cache` in CI, keyed on the pinned version — turning the cold multi-minute install into a few-seconds no-op on a cache hit. Also widens the healthcheck's `retries` to a 10-minute ceiling so a genuine cache miss (first run, or a future cache-key bump) has room to complete instead of racing the same tight window as before.

This mirrors the identical fix already applied in the `zilla-plus` sibling repo's own `mcp.proxy` (and related `embedding.*`) examples, which hit and resolved this exact flake earlier — same mechanism, same rationale, adapted here to `zilla`'s single affected example directory.

### Verification

Reproduced locally (isolated `everything` service): first run populates a 58MB npm cache; a subsequent container recreation reusing that cache goes from container start to healthy in 3 seconds, vs. minutes cold. `compose.yaml` and `build.yml` both validated as syntactically correct (`docker compose config`, YAML parse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YVNaqKvEXZVzmg3HoGVnt

---
_Generated by [Claude Code](https://claude.ai/code/session_015YVNaqKvEXZVzmg3HoGVnt)_