### PR TITLE
fix(binding-kafka): emit a window when a produce flush is acknowledged

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
@@ -1456,10 +1456,8 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                 }
             }
 
-            initialAck += reserved;
-
-            final int noAck = (int) (initialSeq - initialAck);
-            doClientInitialWindow(traceId, noAck, initialBudgetMax);
+            final int noAck = (int) (initialSeq - initialAck - reserved);
+            doClientInitialWindow(traceId, noAck, Math.max(initialMax, initialBudgetMax));
         }
 
         private void onClientInitialEnd(

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheProduceIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheProduceIT.java
@@ -252,6 +252,17 @@ public class CacheProduceIT
     @Test
     @Configuration("cache.yaml")
     @Specification({
+        "${app}/message.value.after.flushes/client",
+        "${app}/message.value.after.flushes/server"})
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldSendMessageValueAfterFlushes() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("cache.yaml")
+    @Specification({
         "${app}/message.value.100k/client",
         "${app}/message.value.100k/server"})
     @ScriptProperty("serverAddress \"zilla://streams/app1\"")

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaChannelConfig.java
@@ -22,6 +22,7 @@ import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.Zill
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_BUDGET_ID;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_BYTE_ORDER;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_CAPABILITIES;
+import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_PADDABLE;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_PADDING;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_REDIRECTED_ID;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_SHARED_WINDOW;
@@ -35,7 +36,9 @@ import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.util.Conve
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.util.Conversions.convertToInt;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.util.Conversions.convertToLong;
 
+import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Set;
 
 import io.aklivity.k3po.runtime.driver.internal.netty.bootstrap.channel.DefaultChannelConfig;
 
@@ -47,6 +50,7 @@ public class DefaultZillaChannelConfig extends DefaultChannelConfig implements Z
     private long budgetId;
     private long streamId;
     private int padding;
+    private Set<ZillaFrameKind> paddable = EnumSet.of(ZillaFrameKind.DATA);
     private ZillaThrottleMode throttle = ZillaThrottleMode.STREAM;
     private ZillaUpdateMode update = ZillaUpdateMode.STREAM;
     private long affinity;
@@ -134,6 +138,23 @@ public class DefaultZillaChannelConfig extends DefaultChannelConfig implements Z
     public int getPadding()
     {
         return padding;
+    }
+
+    @Override
+    public void setPaddable(String paddable)
+    {
+        final Set<ZillaFrameKind> kinds = EnumSet.noneOf(ZillaFrameKind.class);
+        for (String kind : paddable.trim().split("\\s+"))
+        {
+            kinds.add(ZillaFrameKind.decode(kind));
+        }
+        this.paddable = kinds;
+    }
+
+    @Override
+    public boolean isPaddable(ZillaFrameKind kind)
+    {
+        return paddable.contains(kind);
     }
 
     @Override
@@ -252,6 +273,10 @@ public class DefaultZillaChannelConfig extends DefaultChannelConfig implements Z
         else if (OPTION_PADDING.getName().equals(key))
         {
             setPadding(convertToInt(value));
+        }
+        else if (OPTION_PADDABLE.getName().equals(key))
+        {
+            setPaddable(Objects.toString(value, "data"));
         }
         else if (OPTION_UPDATE.getName().equals(key))
         {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaServerChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaServerChannelConfig.java
@@ -21,6 +21,7 @@ import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.behavior.Z
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_BUDGET_ID;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_BYTE_ORDER;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_CAPABILITIES;
+import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_PADDABLE;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_PADDING;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_SHARED_WINDOW;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_STREAM_ID;
@@ -33,7 +34,9 @@ import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.util.Conve
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.util.Conversions.convertToInt;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.util.Conversions.convertToLong;
 
+import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Set;
 
 import io.aklivity.k3po.runtime.driver.internal.netty.bootstrap.channel.DefaultServerChannelConfig;
 
@@ -45,6 +48,7 @@ public class DefaultZillaServerChannelConfig extends DefaultServerChannelConfig 
     private long budgetId;
     private long streamId;
     private int padding;
+    private Set<ZillaFrameKind> paddable = EnumSet.of(ZillaFrameKind.DATA);
     private ZillaThrottleMode throttle = ZillaThrottleMode.STREAM;
     private ZillaUpdateMode update = ZillaUpdateMode.STREAM;
     private long affinity;
@@ -120,6 +124,23 @@ public class DefaultZillaServerChannelConfig extends DefaultServerChannelConfig 
     public int getPadding()
     {
         return padding;
+    }
+
+    @Override
+    public void setPaddable(String paddable)
+    {
+        final Set<ZillaFrameKind> kinds = EnumSet.noneOf(ZillaFrameKind.class);
+        for (String kind : paddable.trim().split("\\s+"))
+        {
+            kinds.add(ZillaFrameKind.decode(kind));
+        }
+        this.paddable = kinds;
+    }
+
+    @Override
+    public boolean isPaddable(ZillaFrameKind kind)
+    {
+        return paddable.contains(kind);
     }
 
     @Override
@@ -252,6 +273,10 @@ public class DefaultZillaServerChannelConfig extends DefaultServerChannelConfig 
         else if (OPTION_PADDING.getName().equals(key))
         {
             setPadding(convertToInt(value));
+        }
+        else if (OPTION_PADDABLE.getName().equals(key))
+        {
+            setPaddable(Objects.toString(value, "data"));
         }
         else if (OPTION_UPDATE.getName().equals(key))
         {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelConfig.java
@@ -41,6 +41,10 @@ public interface ZillaChannelConfig extends ChannelConfig
 
     int getPadding();
 
+    void setPaddable(String paddable);
+
+    boolean isPaddable(ZillaFrameKind kind);
+
     void setUpdate(ZillaUpdateMode update);
 
     ZillaUpdateMode getUpdate();

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaFrameKind.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaFrameKind.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.behavior;
+
+import java.util.Objects;
+
+public enum ZillaFrameKind
+{
+    DATA,
+    FLUSH;
+
+    public static ZillaFrameKind decode(
+        String value)
+    {
+        Objects.requireNonNull(value);
+
+        switch (value)
+        {
+        case "data":
+            return DATA;
+        case "flush":
+            return FLUSH;
+        default:
+            throw new IllegalArgumentException(value);
+        }
+    }
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
@@ -489,7 +489,7 @@ final class ZillaTarget implements AutoCloseable
         final long authorization = channel.targetAuth();
         final int maximum = channel.targetMax();
         final long budgetId = channel.debitorId();
-        final int reservedBytes = channel.reservedBytes(0);
+        final int reservedBytes = channel.getConfig().isPaddable(ZillaFrameKind.FLUSH) ? channel.reservedBytes(0) : 0;
 
         final ChannelBuffer writeExt = channel.writeExtBuffer(FLUSH, true);
         final int writableExtBytes = writeExt.readableBytes();
@@ -714,7 +714,8 @@ final class ZillaTarget implements AutoCloseable
         final boolean flushing = writeBuf == NULL_BUFFER;
         final int writableWin = channel.writableBytes();
         final int reservableBytes = Math.min(writeBuf.readableBytes(), writeBuffer.capacity() >> 1);
-        final int reservedBytes = writableWin > 0 || writeBuf.capacity() == 0 ? channel.reservedBytes(reservableBytes) : 0;
+        final int reservedBytes = channel.getConfig().isPaddable(ZillaFrameKind.DATA) &&
+                (writableWin > 0 || writeBuf.capacity() == 0) ? channel.reservedBytes(reservableBytes) : 0;
         final int writableBytes = Math.max(Math.min(reservedBytes - channel.targetPad(), writeBuf.readableBytes()), 0);
 
         // allow extension-only DATA frames to be flushed immediately

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
@@ -489,6 +489,7 @@ final class ZillaTarget implements AutoCloseable
         final long authorization = channel.targetAuth();
         final int maximum = channel.targetMax();
         final long budgetId = channel.debitorId();
+        final int reservedBytes = channel.reservedBytes(0);
 
         final ChannelBuffer writeExt = channel.writeExtBuffer(FLUSH, true);
         final int writableExtBytes = writeExt.readableBytes();
@@ -505,10 +506,13 @@ final class ZillaTarget implements AutoCloseable
                 .traceId(supplyTraceId.getAsLong())
                 .authorization(authorization)
                 .budgetId(budgetId)
+                .reserved(reservedBytes)
                 .extension(ex -> ex.set(writeExtCopy))
                 .build();
 
         streamsBuffer.write(flush.typeId(), flush.buffer(), flush.offset(), flush.sizeof());
+
+        channel.writtenBytes(0, reservedBytes);
 
         writeExt.skipBytes(writableExtBytes);
         writeExt.discardReadBytes();

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/types/ZillaTypeSystem.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/types/ZillaTypeSystem.java
@@ -37,6 +37,7 @@ public final class ZillaTypeSystem implements TypeSystemSpi
     public static final TypeInfo<Long> OPTION_BUDGET_ID = new TypeInfo<>("budgetId", Long.class);
     public static final TypeInfo<Long> OPTION_STREAM_ID = new TypeInfo<>("streamId", Long.class);
     public static final TypeInfo<Integer> OPTION_PADDING = new TypeInfo<>("padding", Integer.class);
+    public static final TypeInfo<String> OPTION_PADDABLE = new TypeInfo<>("paddable", String.class);
     public static final TypeInfo<String> OPTION_UPDATE = new TypeInfo<>("update", String.class);
     public static final TypeInfo<String> OPTION_TRANSMISSION = new TypeInfo<>("transmission", String.class);
     public static final TypeInfo<String> OPTION_THROTTLE = new TypeInfo<>("throttle", String.class);
@@ -90,6 +91,7 @@ public final class ZillaTypeSystem implements TypeSystemSpi
         acceptOptions.add(OPTION_SHARED_WINDOW);
         acceptOptions.add(OPTION_BUDGET_ID);
         acceptOptions.add(OPTION_PADDING);
+        acceptOptions.add(OPTION_PADDABLE);
         acceptOptions.add(OPTION_UPDATE);
         acceptOptions.add(OPTION_AUTHORIZATION);
         acceptOptions.add(OPTION_THROTTLE);
@@ -110,6 +112,7 @@ public final class ZillaTypeSystem implements TypeSystemSpi
         connectOptions.add(OPTION_BUDGET_ID);
         connectOptions.add(OPTION_STREAM_ID);
         connectOptions.add(OPTION_PADDING);
+        connectOptions.add(OPTION_PADDABLE);
         connectOptions.add(OPTION_UPDATE);
         connectOptions.add(OPTION_AUTHORIZATION);
         connectOptions.add(OPTION_THROTTLE);

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.after.flushes/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.after.flushes/client.rpt
@@ -1,0 +1,82 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:dataEx()
+                             .typeId(zilla:id("kafka"))
+                             .meta()
+                                 .partition(0, 177)
+                                 .build()
+                             .build()}
+
+read notify ROUTED_BROKER_CLIENT
+
+connect await ROUTED_BROKER_CLIENT
+        "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:padding 4096
+    option zilla:transmission "half-duplex"
+    option zilla:affinity 177
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .produce()
+                                   .topic("test")
+                                   .partition(0)
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .topic("test")
+                                  .partition(0)
+                                  .build()
+                              .build()}
+
+write advise zilla:flush
+
+write advise zilla:flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .timestamp(1716424650323)
+                                  .build()
+                              .build()}
+write "Hello, world"
+write flush

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.after.flushes/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.after.flushes/client.rpt
@@ -47,6 +47,7 @@ connect await ROUTED_BROKER_CLIENT
         "zilla://streams/app0"
     option zilla:window 8192
     option zilla:padding 4096
+    option zilla:paddable "data flush"
     option zilla:transmission "half-duplex"
     option zilla:affinity 177
 

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.after.flushes/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.after.flushes/server.rpt
@@ -1,0 +1,76 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+    option zilla:window 8192
+    option zilla:padding 4096
+    option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .partition(0, 177)
+                                  .build()
+                              .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .topic("test")
+                                  .partition(0)
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .produce()
+                                   .topic("test")
+                                   .partition(0)
+                                   .build()
+                               .build()}
+
+read zilla:data.ext ${kafka:matchDataEx()
+                             .typeId(zilla:id("kafka"))
+                             .produce()
+                                 .build()
+                             .build()}
+read "Hello, world"


### PR DESCRIPTION
## Description

Fixes #2517

`KafkaCacheClientProduceFactory$KafkaCacheClientProduceStream.onClientInitialFlush` advanced `initialAck` by the flush's `reserved` bytes itself before asking `doClientInitialWindow` to publish it. That method only writes a WINDOW frame when it observes the acknowledge or the maximum change, and it derives the new acknowledge from the caller's `noAck`: with `initialAck` already advanced, `initialSeq - noAck` resolves back to the current `initialAck`, so the guard never fires and the frame is never written. The credit is released internally and never reaches the sender, whose view of the window shrinks by every flush until it reaches zero.

This is the underlying cause behind the MQTT QoS0-publish-through-mqtt-kafka failure reported in #2523 (a produce entry can be committed via a FLUSH carrying no payload, e.g. for a retained-message tombstone or a bare commit point — every one of those silently starves the sender's window).

Fix passes the outstanding byte count without pre-applying it, so `doClientInitialWindow` advances the acknowledge and emits the frame, and keeps the maximum from regressing below the one already advertised. With a zero-reserved flush this resolves to the previous behaviour.

Credit to community contributor **[@sfr-oc](https://github.com/sfr-oc)**, who diagnosed and fixed this as part of the combined #2523. This PR cherry-picks that fix's commit standalone (unmodified, `9d013389`), since #2523 bundles seven independently-scoped defects across three bindings into one PR — each deserves its own focused review, and this one is ready on its own.

### Test coverage

The k3po test harness had no way to author an application-level FLUSH frame with nonzero `reserved` bytes — `write advise zilla:flush` always emitted `reserved=0` regardless of any configured padding, since that path never consulted it (unlike the DATA write path). That made this fix's own regression untestable from a `.rpt` script.

Rather than special-case FLUSH, added a generalized, opt-in `paddable` connect/accept option (space-separated frame-kind tokens, e.g. `"data flush"`) that controls which frame kinds derive their reserved bytes from the channel's padding accounting — defaulting to `"data"` only, matching every existing script's implicit behavior, so no other scenario changes semantics. The DATA write path now honors the same `isPaddable(DATA)` gate for symmetry.

New scenario `message.value.after.flushes` (`runtime/binding-kafka`'s `CacheProduceIT#shouldSendMessageValueAfterFlushes`): two produce flushes, each consuming half the configured window via padding, followed by a small message value that only fits once the fix restores the window after each flush.

- New paired k3po scripts (`client.rpt` + `server.rpt`) in `specs/binding-kafka.spec`'s `streams/application/produce/message.value.after.flushes/`
- Harness change: `ZillaFrameKind` enum, `paddable` option plumbed through `ZillaTypeSystem`, `ZillaChannelConfig`, `DefaultZillaChannelConfig`, `DefaultZillaServerChannelConfig`, and `ZillaTarget`

### Verification

- Reverted just the production fix and confirmed the new IT fails for the right reason: the client blocks writing the final DATA frame (window never restored after the flushes) until the test times out — then restored the fix and confirmed the test passes
- Ran the full `binding-kafka` and `binding-sse` IT suites (the latter to catch any behavior change from the harness's own advisory-flush path) — both clean
- Full reactor build (`./mvnw clean install`, all ITs) compiles and passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YVNaqKvEXZVzmg3HoGVnt

---
_Generated by [Claude Code](https://claude.ai/code/session_015YVNaqKvEXZVzmg3HoGVnt)_