### PR TITLE
fix(binding-mqtt-kafka): guard KafkaSignalStream flush against non-fetch merged kind

### DIFF
--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionFactory.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionFactory.java
@@ -1707,7 +1707,9 @@ public class MqttKafkaSessionFactory implements MqttKafkaStreamFactory
                 flushEx != null && flushEx.typeId() == kafkaTypeId ? extension.get(kafkaFlushExRO::tryWrap) : null;
             final KafkaMergedFlushExFW kafkaMergedFlushEx =
                 kafkaFlushEx != null && kafkaFlushEx.kind() == KafkaDataExFW.KIND_MERGED ? kafkaFlushEx.merged() : null;
-            final Array32FW<KafkaOffsetFW> progress = kafkaMergedFlushEx != null ? kafkaMergedFlushEx.fetch().progress() : null;
+            final Array32FW<KafkaOffsetFW> progress =
+                kafkaMergedFlushEx != null && kafkaMergedFlushEx.kind() == KafkaMergedFlushExFW.KIND_FETCH ?
+                    kafkaMergedFlushEx.fetch().progress() : null;
 
             if (progress != null)
             {

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionProxyIT.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionProxyIT.java
@@ -224,6 +224,16 @@ public class MqttKafkaSessionProxyIT
     @Configuration("proxy.yaml")
     @Configure(name = PUBLISH_MAX_QOS_NAME, value = "1")
     @Specification({
+        "${kafka}/session.ignore.non.fetch.signal.stream.flush/server"})
+    public void shouldIgnoreNonFetchSignalStreamFlush() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Configure(name = PUBLISH_MAX_QOS_NAME, value = "1")
+    @Specification({
         "${mqtt}/session.will.message.normal.disconnect/client",
         "${kafka}/session.will.message.normal.disconnect/server"})
     public void shouldNotSendWillMessageOnNormalDisconnect() throws Exception

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.ignore.non.fetch.signal.stream.flush/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.ignore.non.fetch.signal.stream.flush/client.rpt
@@ -1,0 +1,75 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property delayMillis 1000L
+property expireAt ${mqtt:timestamp() + delayMillis}
+
+connect "zilla://streams/kafka0"
+         option zilla:window 8192
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .capabilities("PRODUCE_AND_FETCH")
+                                .topic("mqtt-sessions")
+                                .filter()
+                                    .header("type", "will-signal")
+                                    .build()
+                                .filter()
+                                    .header("type", "expiry-signal")
+                                    .build()
+                                .build()
+                            .build()}
+
+connected
+
+read advised zilla:flush
+
+read advised zilla:flush
+
+read advised zilla:flush
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .fetch()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1#expiry")
+                               .header("type", "expiry-signal")
+                               .build()
+                           .build()}
+read ${mqtt:sessionSignal()
+            .expiry()
+                .instanceId("zilla-1")
+                .clientId("client-1")
+                .delay(1000)
+                .expireAt(expireAt)
+                .build()
+            .build()}
+
+# cleanup session state
+write zilla:data.ext ${kafka:dataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .produce()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1")
+                               .hashKey("client-1")
+                               .build()
+                           .build()}
+write flush

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.ignore.non.fetch.signal.stream.flush/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.ignore.non.fetch.signal.stream.flush/server.rpt
@@ -1,0 +1,101 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property delayMillis 1000L
+property expireAt ${mqtt:timestamp() + delayMillis}
+
+accept "zilla://streams/kafka0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+
+
+accepted
+
+read zilla:begin.ext ${kafka:matchBeginEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .capabilities("PRODUCE_AND_FETCH")
+                                .topic("mqtt-sessions")
+                                .filter()
+                                    .header("type", "will-signal")
+                                    .build()
+                                .filter()
+                                    .header("type", "expiry-signal")
+                                    .build()
+                                .build()
+                            .build()}
+
+connected
+
+write advise zilla:flush ${kafka:flushEx()
+                              .typeId(zilla:id("kafka"))
+                              .merged()
+                                .produce()
+                                  .partitionId(0)
+                                  .partitionOffset(1)
+                                  .timestamp(1000)
+                                  .build()
+                              .build()}
+
+write advise zilla:flush ${kafka:flushEx()
+                              .typeId(zilla:id("kafka"))
+                              .merged()
+                                .consumer()
+                                  .progress(0, 1)
+                                  .correlationId(1)
+                                  .build()
+                              .build()}
+
+write advise zilla:flush ${kafka:flushEx()
+                              .typeId(zilla:id("kafka"))
+                              .merged()
+                                .fetch()
+                                  .partition(0, 1)
+                                  .progress(0, 1)
+                                  .build()
+                              .build()}
+
+write zilla:data.ext ${kafka:dataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .fetch()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1#expiry")
+                               .header("type", "expiry-signal")
+                               .build()
+                           .build()}
+write ${mqtt:sessionSignal()
+            .expiry()
+                .instanceId("zilla-1")
+                .clientId("client-1")
+                .delay(1000)
+                .expireAt(expireAt)
+                .build()
+            .build()}
+write flush
+
+# cleanup session state
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .produce()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1")
+                               .hashKey("client-1")
+                               .build()
+                           .build()}
+read zilla:data.null

--- a/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/KafkaIT.java
+++ b/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/KafkaIT.java
@@ -821,6 +821,15 @@ public class KafkaIT
 
     @Test
     @Specification({
+        "${kafka}/session.ignore.non.fetch.signal.stream.flush/client",
+        "${kafka}/session.ignore.non.fetch.signal.stream.flush/server"})
+    public void shouldIgnoreNonFetchSignalStreamFlush() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${kafka}/publish.qos1/client",
         "${kafka}/publish.qos1/server"})
     public void shouldPublishQoS1Message() throws Exception


### PR DESCRIPTION
## Description

`KafkaMergedFlushExFW` is a union discriminated by `kind()` (`produce`, `fetch`, `consumer`). `KafkaSignalStream.onKafkaFlush` in `MqttKafkaSessionFactory` called `.fetch()` on it unconditionally, without first checking that the flush was actually of the `fetch` sub-kind.

This stream is opened with `PRODUCE_AND_FETCH` capabilities — it both produces will/expiry-signal records onto the sessions topic and fetches other instances' signals back on the same merged Kafka subscription — so a `produce`-kind (or `consumer`-kind) flush on it is a normal, frequent occurrence: every produce ack emits one. Reading `.fetch()` off a non-fetch-kind union member returns an unwrapped flyweight, and iterating its `progress` array throws a `NullPointerException` on `Array32FW.buffer()`, terminating the whole engine worker.

The fix guards the read with the same `kind()` check already used one line above for the outer union, mirroring the existing pattern in this method (and in `onKafkaData`, a few lines up, which already gates `kafkaDataEx.kind() == KafkaDataExFW.KIND_MERGED` before touching `.merged()`).

Credit to @sfr-oc for identifying and fixing this.

New coverage: a paired k3po `client.rpt`/`server.rpt` scenario (`session.ignore.non.fetch.signal.stream.flush`) that sends `produce`, `consumer`, and `fetch` kind flushes in sequence on the same merged stream, wired into both `MqttKafkaSessionProxyIT` (against a live engine) and the spec-level `KafkaIT` (peer-to-peer self-consistency). Verified red (reverting the fix reproduces the exact `NullPointerException` on `Array32FW.buffer()`) then green.

Fixes #2519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YVNaqKvEXZVzmg3HoGVnt

---
_Generated by [Claude Code](https://claude.ai/code/session_015YVNaqKvEXZVzmg3HoGVnt)_