### PR TITLE
fix(binding-mqtt-kafka): guard doKafkaData against insufficient window budget

### DIFF
--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionFactory.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionFactory.java
@@ -3026,13 +3026,15 @@ public class MqttKafkaSessionFactory implements MqttKafkaStreamFactory
             int limit,
             Flyweight extension)
         {
+            if (initialSeq + reserved - padding <= initialAck + initialMax)
+            {
+                doData(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                    traceId, authorization, budgetId, flags, reserved, buffer, offset, limit, extension);
 
-            doData(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
-                traceId, authorization, budgetId, flags, reserved, buffer, offset, limit, extension);
+                initialSeq += reserved;
 
-            initialSeq += reserved;
-
-            assert initialSeq - padding <= initialAck + initialMax;
+                assert initialSeq - padding <= initialAck + initialMax;
+            }
         }
 
         protected final void doKafkaData(
@@ -3044,12 +3046,15 @@ public class MqttKafkaSessionFactory implements MqttKafkaStreamFactory
             OctetsFW payload,
             Flyweight extension)
         {
-            doData(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
-                traceId, authorization, budgetId, flags, reserved, payload, extension);
+            if (initialSeq + reserved <= initialAck + initialMax)
+            {
+                doData(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                    traceId, authorization, budgetId, flags, reserved, payload, extension);
 
-            initialSeq += reserved;
+                initialSeq += reserved;
 
-            assert initialSeq <= initialAck + initialMax;
+                assert initialSeq <= initialAck + initialMax;
+            }
         }
 
         protected void doKafkaData(
@@ -3062,17 +3067,20 @@ public class MqttKafkaSessionFactory implements MqttKafkaStreamFactory
             Flyweight payload,
             Flyweight extension)
         {
-            final DirectBufferEx buffer = payload.buffer();
-            final int offset = payload.offset();
-            final int limit = payload.limit();
-            final int length = limit - offset;
+            if (initialSeq + reserved - padding <= initialAck + initialMax)
+            {
+                final DirectBufferEx buffer = payload.buffer();
+                final int offset = payload.offset();
+                final int limit = payload.limit();
+                final int length = limit - offset;
 
-            doData(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
-                traceId, authorization, budgetId, flags, reserved, buffer, offset, length, extension);
+                doData(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                    traceId, authorization, budgetId, flags, reserved, buffer, offset, length, extension);
 
-            initialSeq += reserved;
+                initialSeq += reserved;
 
-            assert initialSeq - padding <= initialAck + initialMax;
+                assert initialSeq - padding <= initialAck + initialMax;
+            }
         }
 
         private void doKafkaFlush(

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionProxyIT.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionProxyIT.java
@@ -298,6 +298,18 @@ public class MqttKafkaSessionProxyIT
 
     @Test
     @Configuration("proxy.yaml")
+    @Configure(name = WILL_AVAILABLE_NAME, value = "false")
+    @Configure(name = PUBLISH_MAX_QOS_NAME, value = "1")
+    @Specification({
+        "${mqtt}/session.will.message.clean.start.abort.zero.window/client",
+        "${kafka}/session.will.message.clean.start.abort.zero.window/server"})
+    public void shouldSkipWillSignalOnAbortBeforeKafkaSessionStreamWindowGranted() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
     @Configure(name = PUBLISH_MAX_QOS_NAME, value = "1")
     @Specification({
         "${mqtt}/session.will.message.abort.deliver.will.retain/client",

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.clean.start.abort.zero.window/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.clean.start.abort.zero.window/client.rpt
@@ -1,0 +1,97 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/kafka0"
+         option zilla:window 67
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .capabilities("PRODUCE_ONLY")
+                                .topic("mqtt-sessions")
+                                .filter()
+                                    .key("client-1")
+                                    .build()
+                                .build()
+                            .build()}
+
+connected
+
+# no will cancellation signal due to clean-start
+
+# session expiry cancellation signal for client-1
+write zilla:data.ext ${kafka:dataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .produce()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1#expiry")
+                               .hashKey("client-1")
+                               .header("type", "expiry-signal")
+                               .build()
+                           .build()}
+write flush
+
+# session expire-later signal for client-1
+write zilla:data.ext ${kafka:dataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .produce()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1#expiry")
+                               .hashKey("client-1")
+                               .header("type", "expiry-signal")
+                               .build()
+                           .build()}
+write ${mqtt:sessionSignal()
+            .expiry()
+                .instanceId("zilla-1")
+                .clientId("client-1")
+                .delay(1000)
+                .expireAt(-1)
+                .build()
+            .build()}
+write flush
+
+# no will signal: not self-covered by session padding, so it is skipped
+# rather than written now that the real window is too small for it
+
+# real session-expire-at signal on abort: self-covered by its own padding
+write zilla:data.ext ${kafka:dataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .produce()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1#expiry")
+                               .hashKey("client-1")
+                               .header("type", "expiry-signal")
+                               .build()
+                           .build()}
+write ${mqtt:sessionSignal()
+            .expiry()
+                .instanceId("zilla-1")
+                .clientId("client-1")
+                .delay(1000)
+                .expireAt(2000)
+                .build()
+            .build()}
+write flush
+
+write abort
+read aborted

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.clean.start.abort.zero.window/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.clean.start.abort.zero.window/server.rpt
@@ -1,0 +1,110 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# the session's own kafka producer stream (mqtt-sessions, PRODUCE_ONLY) is
+# granted a real window just large enough to cover the self-covering expiry
+# writes below, but too small to also cover the eager will signal on abort --
+# this is the production gap between an attached kafka stream and the merged
+# kafka binding's async partition/metadata resolution granting real credit
+accept "zilla://streams/kafka0"
+        option zilla:window 67
+        option zilla:update "handshake"
+        option zilla:transmission "duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:matchBeginEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .capabilities("PRODUCE_ONLY")
+                                .topic("mqtt-sessions")
+                                .filter()
+                                    .key("client-1")
+                                    .build()
+                                .build()
+                            .build()}
+
+connected
+
+# no will cancellation signal due to clean-start
+
+# session expiry cancellation signal for client-1: the very first real
+# WINDOW to arrive triggers the one-time "wasOpen" cascade
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .produce()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1#expiry")
+                               .hashKey("client-1")
+                               .header("type", "expiry-signal")
+                               .build()
+                           .build()}
+read zilla:data.null
+
+# session expire-later signal for client-1
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .produce()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1#expiry")
+                               .hashKey("client-1")
+                               .header("type", "expiry-signal")
+                               .build()
+                           .build()}
+read ${mqtt:sessionSignal()
+           .expiry()
+               .instanceId("zilla-1")
+               .clientId("client-1")
+               .delay(1000)
+               .expireAt(-1)
+               .build()
+           .build()}
+
+# the session's kafka producer stream now has its real (small) window
+# granted; releasing the client's abort here reproduces the production gap
+# this regression guards -- the will signal below is not self-covered by
+# session padding the way the expiry writes are, so it must be skipped
+# rather than written
+write notify SESSION_STREAM_WINDOW_GRANTED
+
+# real session-expire-at signal on abort: self-covered by its own padding,
+# so it is written even though the real window is too small for the will
+# signal
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .produce()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1#expiry")
+                               .hashKey("client-1")
+                               .header("type", "expiry-signal")
+                               .build()
+                           .build()}
+read ${mqtt:sessionSignal()
+           .expiry()
+               .instanceId("zilla-1")
+               .clientId("client-1")
+               .delay(1000)
+               .expireAt(2000)
+               .build()
+           .build()}
+
+read aborted
+write abort

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.clean.start.abort.zero.window/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.clean.start.abort.zero.window/client.rpt
@@ -1,0 +1,42 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# clean-start session with a will, established while the session's own kafka
+# producer stream is granted only a small real window -- simulating the gap
+# before the merged kafka binding's async partition/metadata resolution has
+# completed; the client aborts only once that real window has been granted,
+# so the eager will signal write is not self-covered by session padding the
+# way the expiry writes are, and must be skipped rather than assert-crash
+# the engine worker
+connect "zilla://streams/mqtt0"
+         option zilla:window 8192
+         option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mqtt:beginEx()
+                           .typeId(zilla:id("mqtt"))
+                           .session()
+                              .flags("WILL", "CLEAN_START")
+                              .expiry(1)
+                              .capabilities("REDIRECT")
+                              .clientId("client-1")
+                              .build()
+                           .build()}
+
+connected
+
+# no will data was ever written, so the will signal carries no lifetimeId
+# or willId
+write await SESSION_STREAM_WINDOW_GRANTED
+write abort

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.clean.start.abort.zero.window/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.clean.start.abort.zero.window/server.rpt
@@ -1,0 +1,34 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/mqtt0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .flags("WILL", "CLEAN_START")
+                                .expiry(1)
+                                .capabilities("REDIRECT")
+                                .clientId("client-1")
+                                .build()
+                             .build()}
+
+connected
+
+read aborted

--- a/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/KafkaIT.java
+++ b/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/KafkaIT.java
@@ -776,6 +776,15 @@ public class KafkaIT
 
     @Test
     @Specification({
+        "${kafka}/session.will.message.clean.start.abort.zero.window/client",
+        "${kafka}/session.will.message.clean.start.abort.zero.window/server"})
+    public void shouldSkipWillSignalOnAbortBeforeKafkaSessionStreamWindowGranted() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${kafka}/session.will.message.cancel.delivery/client",
         "${kafka}/session.will.message.cancel.delivery/server"})
     public void shouldCancelWillDelivery() throws Exception

--- a/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/MqttIT.java
+++ b/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/MqttIT.java
@@ -652,6 +652,17 @@ public class MqttIT
 
     @Test
     @Specification({
+        "${mqtt}/session.will.message.clean.start.abort.zero.window/client",
+        "${mqtt}/session.will.message.clean.start.abort.zero.window/server"})
+    public void shouldSkipWillSignalOnAbortBeforeKafkaSessionStreamWindowGranted() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("SESSION_STREAM_WINDOW_GRANTED");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${mqtt}/publish.qos1/client",
         "${mqtt}/publish.qos1/server"})
     public void shouldPublishQoS1Message() throws Exception


### PR DESCRIPTION
## Description

`KafkaSessionStream.doKafkaData` (three overloads, in `MqttKafkaSessionFactory`) called `doData(kafka, ...)` unconditionally, then asserted `initialSeq - padding <= initialAck + initialMax` after the fact. `KafkaSessionStateProxy`'s own kafka producer stream (topic `mqtt-sessions`) gets its `kafka` field assigned synchronously as soon as `doKafkaBeginIfNecessary` runs, but `initialMax` stays at its Java default `0` until the merged Kafka binding's async partition/metadata DESCRIBE resolves and grants a real window (see `KafkaMergedFactory.onMergedInitialBegin`, which kicks off `describeStream.doDescribeInitialBegin` rather than synchronously granting credit). A client that aborts with its Will flag set during that gap reaches `onMqttAbort` → `sendWillSignal` → `doKafkaData` with a real (non-null) `kafka` stream but zero window, tripping the assert and crashing the entire engine worker via `AgentTerminationException` — every connection on that worker goes down with it.

The original community-reported fix (credit to @sfr-oc for identifying and reporting this in #2520) guarded only the narrower `kafka == null` case (reachable via `EngineWorker.onClose`'s synthetic-abort sweep hitting a stream mid-registration). This PR instead guards each `doKafkaData` overload with the same inequality the existing `assert` already expressed, checked *before* attempting the write instead of after. This subsumes the `kafka == null` case for free (an unattached stream always has `initialMax == 0`) while also covering the more general, more reachable "attached but zero window" case that the narrower guard didn't touch.

New coverage: `session.will.message.clean.start.abort.zero.window` grants the session's kafka stream a real window just large enough for the self-covering expiry-signal writes but too small for the will signal, then aborts. Verified red (reverting the fix reproduces the exact `AssertionError`/`AgentTerminationException` crash, killing `engine/worker#0`) then green, plus `MqttIT`/`KafkaIT` peer-to-peer self-consistency coverage. Full `runtime/binding-mqtt-kafka` and `specs/binding-mqtt-kafka.spec` module suites pass.

Fixes #2520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YVNaqKvEXZVzmg3HoGVnt

---
_Generated by [Claude Code](https://claude.ai/code/session_015YVNaqKvEXZVzmg3HoGVnt)_