### PR TITLE
fix(binding-mcp-openapi): correct proxy exit schema and route filtering

### DIFF
--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiBindingConfig.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiBindingConfig.java
@@ -58,7 +58,11 @@ public final class McpOpenapiBindingConfig
         this.qname = binding.qname;
         this.kind = binding.kind;
         this.options = (McpOpenapiOptionsConfig) binding.options;
+
+        // a top-level exit: shorthand synthesizes its own catch-all last route (empty when, no with,
+        // exit set) on this same binding -- exclude it here so it never counts as a declared tool route
         this.routes = binding.routes.stream()
+            .filter(route -> route.exit == null)
             .map(McpOpenapiRouteConfig::new)
             .collect(toList());
 

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
@@ -527,14 +527,7 @@
                                     {
                                         "items":
                                         {
-                                            "if":
-                                            {
-                                                "required": [ "with" ]
-                                            },
-                                            "then":
-                                            {
-                                                "required": [ "exit" ]
-                                            }
+                                            "required": [ "exit" ]
                                         }
                                     }
                                 },


### PR DESCRIPTION
## Description

Two small fixes to `binding-mcp-openapi`'s handling of `kind: proxy` and its `exit` requirement:

1. **Schema**: the `kind: proxy` JSON schema patch required a route's `exit` only conditionally on that route having `with` (`if: required with, then: required exit`). Every mcp-openapi route already unconditionally requires `with`, so that conditional never actually excluded anything — it was dead/misleading schema logic carried over from `binding-mcp-http`, where the same clause is genuinely conditional (mcp-http routes can be `with`-less). Replaced it with a plain unconditional `required: [ "exit" ]` for that alternative, which is behaviorally identical (verified against all existing `SchemaTest` fixtures) but no longer implies a condition that can't actually occur.

2. **Config**: a binding's top-level `exit:` shorthand is synthesized by the engine as an extra catch-all last route (empty `when`, no `with`, `exit` set) appended to `binding.routes`. Sibling bindings `McpKafkaConnectBindingConfig` and `McpSchemaRegistryBindingConfig` already filter this synthetic route out before exposing `this.routes`, with a comment explaining why. `McpOpenapiBindingConfig` was missing this filter, so the synthetic route flowed into `this.routes` — currently harmless only because the sole consumer (`McpOpenapiCompositeGenerator`) happens to separately guard `with == null`, but `McpOpenapiRouteConfig.isBulk()` itself dereferences `with` unconditionally, so this was a latent NPE risk for any future consumer of `routes` that assumes `with` is always present. Added the same filter, mirroring the sibling bindings exactly.

Neither change affects observable behavior of any currently-valid configuration.

## Test plan

- `./mvnw clean verify -pl specs/binding-mcp-openapi.spec`: 14/14 `SchemaTest` cases + 17/17 spec ITs (`McpServerIT`, `HttpClientIT`) pass
- `./mvnw clean verify -pl runtime/binding-mcp-openapi`: 58/58 unit tests (incl. the 57-case `McpOpenapiCompositeGeneratorTest`, which iterates `binding.routes`) + 26/26 ITs (`McpOpenapiProxyIT`, `McpOpenapiClientIT`, exercising proxy-kind end-to-end against a live engine) pass
- Checkstyle clean, JaCoCo coverage checks met, NOTICE up to date on both modules
- Independently re-validated the schema equivalence with a standalone draft-2019-09 JSON Schema check (base engine schema + real patches applied in `ConfigSchemaRule`'s order) against all `SchemaTest` fixtures, comparing pre- and post-fix behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBDndP49e5oZjtxYNmzH5h

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBDndP49e5oZjtxYNmzH5h)_