### PR TITLE
fix(common-feature): stop @Internal from leaking via version-string fallback

### DIFF
--- a/examples/inspect.schema/.github/schema.expected.json
+++ b/examples/inspect.schema/.github/schema.expected.json
@@ -5254,16 +5254,9 @@
                                         "properties": {
                                             "routes": {
                                                 "items": {
-                                                    "if": {
-                                                        "required": [
-                                                            "with"
-                                                        ]
-                                                    },
-                                                    "then": {
-                                                        "required": [
-                                                            "exit"
-                                                        ]
-                                                    }
+                                                    "required": [
+                                                        "exit"
+                                                    ]
                                                 }
                                             }
                                         },

--- a/examples/inspect.schema/.github/schema.expected.json
+++ b/examples/inspect.schema/.github/schema.expected.json
@@ -5254,9 +5254,16 @@
                                         "properties": {
                                             "routes": {
                                                 "items": {
-                                                    "required": [
-                                                        "exit"
-                                                    ]
+                                                    "if": {
+                                                        "required": [
+                                                            "with"
+                                                        ]
+                                                    },
+                                                    "then": {
+                                                        "required": [
+                                                            "exit"
+                                                        ]
+                                                    }
                                                 }
                                             }
                                         },

--- a/runtime/common-feature/src/main/java/io/aklivity/zilla/runtime/common/feature/FeatureFilter.java
+++ b/runtime/common-feature/src/main/java/io/aklivity/zilla/runtime/common/feature/FeatureFilter.java
@@ -73,7 +73,10 @@ public final class FeatureFilter
     private static boolean isDevelopSnapshot()
     {
         return isUnnamedModule() || "develop-SNAPSHOT".equals(
-            FeatureFilter.class.getModule().getDescriptor().version().map(ModuleDescriptor.Version::toString)
+            FeatureFilter.class.getModule()
+                .getDescriptor()
+                .version()
+                .map(ModuleDescriptor.Version::toString)
                 .orElse("develop-SNAPSHOT"));
     }
 

--- a/runtime/common-feature/src/main/java/io/aklivity/zilla/runtime/common/feature/FeatureFilter.java
+++ b/runtime/common-feature/src/main/java/io/aklivity/zilla/runtime/common/feature/FeatureFilter.java
@@ -65,13 +65,6 @@ public final class FeatureFilter
         return override != null ? Boolean.parseBoolean(override) : isDevelopSnapshot();
     }
 
-    // Unlike incubatorEnabled(), this has no override branch and must not fall back to
-    // isDevelopSnapshot()'s version-string check: a fully packaged, modularized artifact
-    // (module.getDescriptor() != null) always has a real module, even when its version
-    // happens to be "develop-SNAPSHOT" (e.g. a downstream project temporarily pinned to an
-    // unreleased dependency). Falling back to the version string there would let @Internal
-    // leak into a real packaged build, contradicting its only guarantee: never reachable
-    // outside an unpackaged (unnamed-module) build.
     private static boolean internalEnabled()
     {
         return isUnnamedModule();

--- a/runtime/common-feature/src/main/java/io/aklivity/zilla/runtime/common/feature/FeatureFilter.java
+++ b/runtime/common-feature/src/main/java/io/aklivity/zilla/runtime/common/feature/FeatureFilter.java
@@ -65,17 +65,29 @@ public final class FeatureFilter
         return override != null ? Boolean.parseBoolean(override) : isDevelopSnapshot();
     }
 
+    // Unlike incubatorEnabled(), this has no override branch and must not fall back to
+    // isDevelopSnapshot()'s version-string check: a fully packaged, modularized artifact
+    // (module.getDescriptor() != null) always has a real module, even when its version
+    // happens to be "develop-SNAPSHOT" (e.g. a downstream project temporarily pinned to an
+    // unreleased dependency). Falling back to the version string there would let @Internal
+    // leak into a real packaged build, contradicting its only guarantee: never reachable
+    // outside an unpackaged (unnamed-module) build.
     private static boolean internalEnabled()
     {
-        return isDevelopSnapshot();
+        return isUnnamedModule();
     }
 
     private static boolean isDevelopSnapshot()
     {
+        return isUnnamedModule() || "develop-SNAPSHOT".equals(
+            FeatureFilter.class.getModule().getDescriptor().version().map(ModuleDescriptor.Version::toString)
+                .orElse("develop-SNAPSHOT"));
+    }
+
+    private static boolean isUnnamedModule()
+    {
         final Module module = FeatureFilter.class.getModule();
 
-        return module == null || module.getDescriptor() == null || "develop-SNAPSHOT".equals(
-            module.getDescriptor().version().map(ModuleDescriptor.Version::toString)
-                .orElse("develop-SNAPSHOT"));
+        return module == null || module.getDescriptor() == null;
     }
 }


### PR DESCRIPTION
## Description

`@Internal` (#2419) is documented to be "never reachable in a real release, under any configuration" — a stricter, non-overridable counterpart to `@Incubating`, which keeps a real, documented `zilla.incubator.enabled` escape hatch even in a tagged release.

`internalEnabled()` previously delegated to the same `isDevelopSnapshot()` helper `@Incubating`'s own default branch uses:

```java
private static boolean isDevelopSnapshot()
{
    final Module module = FeatureFilter.class.getModule();
    return module == null || module.getDescriptor() == null || "develop-SNAPSHOT".equals(
        module.getDescriptor().version().map(ModuleDescriptor.Version::toString).orElse("develop-SNAPSHOT"));
}
```

This conflates two genuinely different conditions:

- `module == null || module.getDescriptor() == null` — true for an **unnamed-module** (classpath-style) build, exactly what Surefire/Failsafe run against before `moditect-maven-plugin` ever stamps a module descriptor onto a packaged jar. This is the condition that actually matters for `@Internal`: it's what makes an `@Internal` component visible to this repo's own pre-packaging unit/IT tests.
- `"develop-SNAPSHOT".equals(version)` — true whenever a **fully packaged, modularized** artifact (real module descriptor either way) happens to carry that literal version string.

For `@Incubating`, the version-string branch is a reasonable default (smoothing local development against snapshot builds), coexisting with its own real, supported override. For `@Internal`, it's wrong: a fully packaged artifact is not "still under test" just because its own version string happens to be `develop-SNAPSHOT` — `module.getDescriptor() != null` regardless. Any consumer building a real packaged/modularized artifact against an unreleased `develop-SNAPSHOT` version of this artifact — for reasons entirely unrelated to `@Internal` components — would still leak every `@Internal`-annotated component into that real, packaged build, contradicting the "never reachable in a real release, under any configuration" guarantee `@Internal` exists to provide.

This splits the unnamed-module check out into its own helper and uses only that for `internalEnabled()`, keeping the version-string fallback exclusive to `incubatorEnabled()`, where it's a deliberate default alongside a real override.

## Testing

- `./mvnw test -pl runtime/common-feature` — checkstyle clean, all 4 `FeatureFilterTest` tests pass.
- `./mvnw test -pl config/engine.conf -Dtest=FactoryTest` — all 3 tests pass, including `shouldFilterInternalIdenticallyToMapOverload`.
- No test changes needed: both test classes' `@Internal` coverage runs via Surefire against an unnamed module (before `moditect` ever runs), so it's unaffected by removing the version-string branch either way — the existing assertions are self-consistency checks (comparing `FeatureFilter`'s own output to itself via a second code path), not hardcoded outcomes tied to a specific version string.

https://claude.ai/code/session_01Rr8sMJV5WVRe48th8E9TtQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rr8sMJV5WVRe48th8E9TtQ)_