### PR TITLE
refactor(engine.conf): resolve qname once at engine load time via Config.Reference

### DIFF
--- a/config/binding-echo.conf/src/main/java/io/aklivity/zilla/config/binding/echo/EchoOptionsConfig.java
+++ b/config/binding-echo.conf/src/main/java/io/aklivity/zilla/config/binding/echo/EchoOptionsConfig.java
@@ -17,8 +17,8 @@ package io.aklivity.zilla.config.binding.echo;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public final class EchoOptionsConfig extends OptionsConfig
@@ -38,7 +38,7 @@ public final class EchoOptionsConfig extends OptionsConfig
 
     EchoOptionsConfig(
         ModelConfig value,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super(null, refs);
         this.value = value;

--- a/config/binding-echo.conf/src/main/java/io/aklivity/zilla/config/binding/echo/EchoOptionsConfigBuilder.java
+++ b/config/binding-echo.conf/src/main/java/io/aklivity/zilla/config/binding/echo/EchoOptionsConfigBuilder.java
@@ -17,9 +17,9 @@ package io.aklivity.zilla.config.binding.echo;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public final class EchoOptionsConfigBuilder<T> extends ConfigBuilder<T, EchoOptionsConfigBuilder<T>>
@@ -51,7 +51,7 @@ public final class EchoOptionsConfigBuilder<T> extends ConfigBuilder<T, EchoOpti
     @Override
     public T build()
     {
-        List<NamedConfig> refs = value != null ? value.refs() : List.of();
+        List<Config.Reference> refs = value != null ? value.refs() : List.of();
         return mapper.apply(new EchoOptionsConfig(value, refs));
     }
 }

--- a/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpOptionsConfig.java
+++ b/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpOptionsConfig.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.function.Function;
 
-import io.aklivity.zilla.config.engine.NamedConfig;
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public final class HttpOptionsConfig extends OptionsConfig
@@ -47,7 +47,7 @@ public final class HttpOptionsConfig extends OptionsConfig
         HttpAccessControlConfig access,
         HttpAuthorizationConfig authorization,
         List<HttpRequestConfig> requests,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super(null, refs);
         this.versions = versions;

--- a/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpOptionsConfigBuilder.java
+++ b/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpOptionsConfigBuilder.java
@@ -23,8 +23,8 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public final class HttpOptionsConfigBuilder<T> extends ConfigBuilder<T, HttpOptionsConfigBuilder<T>>
@@ -127,7 +127,7 @@ public final class HttpOptionsConfigBuilder<T> extends ConfigBuilder<T, HttpOpti
     @Override
     public T build()
     {
-        List<NamedConfig> refs = new ArrayList<>();
+        List<Config.Reference> refs = new ArrayList<>();
         if (requests != null)
         {
             for (HttpRequestConfig request : requests)

--- a/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpParamConfig.java
+++ b/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpParamConfig.java
@@ -20,25 +20,24 @@ import java.util.List;
 
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class HttpParamConfig extends Config
 {
     public String name;
     public ModelConfig model;
-    private final List<NamedConfig> refs;
+    private final List<Config.Reference> refs;
 
     HttpParamConfig(
         String name,
         ModelConfig model,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         this.name = name;
         this.model = model;
         this.refs = refs;
     }
 
-    public List<NamedConfig> refs()
+    public List<Config.Reference> refs()
     {
         return refs;
     }

--- a/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpParamConfigBuilder.java
+++ b/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpParamConfigBuilder.java
@@ -17,9 +17,9 @@ package io.aklivity.zilla.config.binding.http;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class HttpParamConfigBuilder<T> extends ConfigBuilder<T, HttpParamConfigBuilder<T>>
 {
@@ -64,7 +64,7 @@ public class HttpParamConfigBuilder<T> extends ConfigBuilder<T, HttpParamConfigB
     @Override
     public T build()
     {
-        List<NamedConfig> refs = model != null ? model.refs() : List.of();
+        List<Config.Reference> refs = model != null ? model.refs() : List.of();
         return mapper.apply(new HttpParamConfig(name, model, refs));
     }
 }

--- a/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpRequestConfig.java
+++ b/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpRequestConfig.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class HttpRequestConfig extends Config
 {
@@ -44,7 +43,7 @@ public class HttpRequestConfig extends Config
     public final List<HttpParamConfig> queryParams;
     public final ModelConfig content;
     public final List<HttpResponseConfig> responses;
-    private final List<NamedConfig> refs;
+    private final List<Config.Reference> refs;
 
     HttpRequestConfig(
         String path,
@@ -55,7 +54,7 @@ public class HttpRequestConfig extends Config
         List<HttpParamConfig> queryParams,
         ModelConfig content,
         List<HttpResponseConfig> responses,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         this.path = path;
         this.method = method;
@@ -68,7 +67,7 @@ public class HttpRequestConfig extends Config
         this.refs = refs;
     }
 
-    public List<NamedConfig> refs()
+    public List<Config.Reference> refs()
     {
         return refs;
     }

--- a/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpRequestConfigBuilder.java
+++ b/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpRequestConfigBuilder.java
@@ -19,9 +19,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class HttpRequestConfigBuilder<T> extends ConfigBuilder<T, HttpRequestConfigBuilder<T>>
 {
@@ -190,7 +190,7 @@ public class HttpRequestConfigBuilder<T> extends ConfigBuilder<T, HttpRequestCon
     @Override
     public T build()
     {
-        List<NamedConfig> refs = new ArrayList<>();
+        List<Config.Reference> refs = new ArrayList<>();
         if (content != null)
         {
             refs.addAll(content.refs());

--- a/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpResponseConfig.java
+++ b/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpResponseConfig.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class HttpResponseConfig extends Config
 {
@@ -28,14 +27,14 @@ public class HttpResponseConfig extends Config
     public final List<String> contentType;
     public final List<HttpParamConfig> headers;
     public final ModelConfig content;
-    private final List<NamedConfig> refs;
+    private final List<Config.Reference> refs;
 
     HttpResponseConfig(
         List<String> status,
         List<String> contentType,
         List<HttpParamConfig> headers,
         ModelConfig content,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         this.status = status;
         this.contentType = contentType;
@@ -44,7 +43,7 @@ public class HttpResponseConfig extends Config
         this.refs = refs;
     }
 
-    public List<NamedConfig> refs()
+    public List<Config.Reference> refs()
     {
         return refs;
     }

--- a/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpResponseConfigBuilder.java
+++ b/config/binding-http.conf/src/main/java/io/aklivity/zilla/config/binding/http/HttpResponseConfigBuilder.java
@@ -19,9 +19,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class HttpResponseConfigBuilder<T> extends ConfigBuilder<T, HttpResponseConfigBuilder<T>>
 {
@@ -107,7 +107,7 @@ public class HttpResponseConfigBuilder<T> extends ConfigBuilder<T, HttpResponseC
     @Override
     public T build()
     {
-        List<NamedConfig> refs = new ArrayList<>();
+        List<Config.Reference> refs = new ArrayList<>();
         if (content != null)
         {
             refs.addAll(content.refs());

--- a/config/binding-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/kafka/KafkaOptionsConfig.java
+++ b/config/binding-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/kafka/KafkaOptionsConfig.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.config.binding.kafka;
 import java.util.List;
 import java.util.function.Function;
 
-import io.aklivity.zilla.config.engine.NamedConfig;
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public final class KafkaOptionsConfig extends OptionsConfig
@@ -43,7 +43,7 @@ public final class KafkaOptionsConfig extends OptionsConfig
         List<KafkaTopicConfig> topics,
         List<KafkaServerConfig> servers,
         KafkaAuthorizationConfig authorization,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super(null, refs);
         this.bootstrap = bootstrap;

--- a/config/binding-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/kafka/KafkaOptionsConfigBuilder.java
+++ b/config/binding-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/kafka/KafkaOptionsConfigBuilder.java
@@ -19,8 +19,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public final class KafkaOptionsConfigBuilder<T> extends ConfigBuilder<T, KafkaOptionsConfigBuilder<T>>
@@ -106,7 +106,7 @@ public final class KafkaOptionsConfigBuilder<T> extends ConfigBuilder<T, KafkaOp
     @Override
     public T build()
     {
-        List<NamedConfig> refs = new ArrayList<>();
+        List<Config.Reference> refs = new ArrayList<>();
         if (topics != null)
         {
             for (KafkaTopicConfig topic : topics)

--- a/config/binding-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/kafka/KafkaTopicConfig.java
+++ b/config/binding-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/kafka/KafkaTopicConfig.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class KafkaTopicConfig extends Config
 {
@@ -30,7 +29,7 @@ public class KafkaTopicConfig extends Config
     public final ModelConfig key;
     public final ModelConfig value;
     public final KafkaTopicTransformsConfig transforms;
-    private final List<NamedConfig> refs;
+    private final List<Config.Reference> refs;
 
     public static KafkaTopicConfigBuilder<KafkaTopicConfig> builder()
     {
@@ -50,7 +49,7 @@ public class KafkaTopicConfig extends Config
         ModelConfig key,
         ModelConfig value,
         KafkaTopicTransformsConfig transforms,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         this.name = name;
         this.defaultOffset = defaultOffset;
@@ -61,7 +60,7 @@ public class KafkaTopicConfig extends Config
         this.refs = refs;
     }
 
-    public List<NamedConfig> refs()
+    public List<Config.Reference> refs()
     {
         return refs;
     }

--- a/config/binding-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/kafka/KafkaTopicConfigBuilder.java
+++ b/config/binding-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/kafka/KafkaTopicConfigBuilder.java
@@ -18,9 +18,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public final class KafkaTopicConfigBuilder<T> extends ConfigBuilder<T, KafkaTopicConfigBuilder<T>>
 {
@@ -108,7 +108,7 @@ public final class KafkaTopicConfigBuilder<T> extends ConfigBuilder<T, KafkaTopi
     @Override
     public T build()
     {
-        List<NamedConfig> refs = new ArrayList<>();
+        List<Config.Reference> refs = new ArrayList<>();
         if (key != null)
         {
             refs.addAll(key.refs());

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpCacheToolsConfig.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpCacheToolsConfig.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.Config;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public final class McpCacheToolsConfig extends Config.Extensible
 {
@@ -39,11 +38,11 @@ public final class McpCacheToolsConfig extends Config.Extensible
 
     // search and eager may each contribute their own named references; folding both in here lets
     // McpCacheConfig discover every name under tools generically via tools.refs()
-    private static List<NamedConfig> withSearchAndEager(
+    private static List<Config.Reference> withSearchAndEager(
         McpCacheToolsSearchConfig search,
         List<McpToolsEagerConfig> eager)
     {
-        List<NamedConfig> all = new ArrayList<>();
+        List<Config.Reference> all = new ArrayList<>();
         if (search != null)
         {
             all.addAll(search.refs());

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpCacheToolsSearchConfig.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpCacheToolsSearchConfig.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.Config;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public final class McpCacheToolsSearchConfig extends Config.Extensible
 {
@@ -49,10 +48,10 @@ public final class McpCacheToolsSearchConfig extends Config.Extensible
 
     // each configured index may itself contribute named references (e.g. an embedding vault); folding
     // them in here lets McpCacheToolsConfig discover every name under search generically via search.refs()
-    private static List<NamedConfig> withIndexes(
+    private static List<Config.Reference> withIndexes(
         List<McpToolSearchIndexConfig> indexes)
     {
-        List<NamedConfig> all = new ArrayList<>();
+        List<Config.Reference> all = new ArrayList<>();
         if (indexes != null)
         {
             for (McpToolSearchIndexConfig index : indexes)

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpOptionsConfig.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpOptionsConfig.java
@@ -17,8 +17,8 @@ package io.aklivity.zilla.config.binding.mcp;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public final class McpOptionsConfig extends OptionsConfig
@@ -35,7 +35,7 @@ public final class McpOptionsConfig extends OptionsConfig
         McpCacheConfig cache,
         String server,
         ModelConfig tools,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super(null, refs);
         this.elicitation = elicitation;

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpOptionsConfigBuilder.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpOptionsConfigBuilder.java
@@ -18,9 +18,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public final class McpOptionsConfigBuilder<T> extends ConfigBuilder<T, McpOptionsConfigBuilder<T>>
@@ -99,7 +99,7 @@ public final class McpOptionsConfigBuilder<T> extends ConfigBuilder<T, McpOption
     @Override
     public T build()
     {
-        List<NamedConfig> refs = new ArrayList<>();
+        List<Config.Reference> refs = new ArrayList<>();
         if (tools != null)
         {
             refs.addAll(tools.refs());

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpToolSearchIndexConfig.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpToolSearchIndexConfig.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.config.binding.mcp;
 import java.util.List;
 
 import io.aklivity.zilla.config.engine.Config;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public abstract class McpToolSearchIndexConfig extends Config
 {
@@ -29,7 +28,7 @@ public abstract class McpToolSearchIndexConfig extends Config
         this.type = type;
     }
 
-    public List<NamedConfig> refs()
+    public List<Config.Reference> refs()
     {
         return List.of();
     }

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpToolsEagerConfig.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpToolsEagerConfig.java
@@ -17,7 +17,6 @@ package io.aklivity.zilla.config.binding.mcp;
 import java.util.List;
 
 import io.aklivity.zilla.config.engine.Config;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public abstract class McpToolsEagerConfig extends Config
 {
@@ -29,7 +28,7 @@ public abstract class McpToolsEagerConfig extends Config
         this.type = type;
     }
 
-    public List<NamedConfig> refs()
+    public List<Config.Reference> refs()
     {
         return List.of();
     }

--- a/config/binding-mcp.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/McpConfigTest.java
+++ b/config/binding-mcp.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/McpConfigTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.junit.Test;
 
-import io.aklivity.zilla.config.engine.NamedConfig;
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.VaultedConfig;
 
 public class McpConfigTest
@@ -141,17 +141,17 @@ public class McpConfigTest
 
     private static final class McpRefTestToolSearchIndexConfig extends McpToolSearchIndexConfig
     {
-        private final List<NamedConfig> refs;
+        private final List<Config.Reference> refs;
 
         McpRefTestToolSearchIndexConfig(
-            NamedConfig ref)
+            Config.Reference ref)
         {
             super("test");
             this.refs = List.of(ref);
         }
 
         @Override
-        public List<NamedConfig> refs()
+        public List<Config.Reference> refs()
         {
             return refs;
         }
@@ -159,17 +159,17 @@ public class McpConfigTest
 
     private static final class McpRefTestToolsEagerConfig extends McpToolsEagerConfig
     {
-        private final List<NamedConfig> refs;
+        private final List<Config.Reference> refs;
 
         McpRefTestToolsEagerConfig(
-            NamedConfig ref)
+            Config.Reference ref)
         {
             super("test");
             this.refs = List.of(ref);
         }
 
         @Override
-        public List<NamedConfig> refs()
+        public List<Config.Reference> refs()
         {
             return refs;
         }

--- a/config/binding-mqtt.conf/src/main/java/io/aklivity/zilla/config/binding/mqtt/MqttOptionsConfig.java
+++ b/config/binding-mqtt.conf/src/main/java/io/aklivity/zilla/config/binding/mqtt/MqttOptionsConfig.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.config.binding.mqtt;
 import java.util.List;
 import java.util.function.Function;
 
-import io.aklivity.zilla.config.engine.NamedConfig;
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public class MqttOptionsConfig extends OptionsConfig
@@ -45,7 +45,7 @@ public class MqttOptionsConfig extends OptionsConfig
         List<MqttVersion> versions,
         String store,
         String server,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super(null, refs);
         this.authorization = authorization;

--- a/config/binding-mqtt.conf/src/main/java/io/aklivity/zilla/config/binding/mqtt/MqttOptionsConfigBuilder.java
+++ b/config/binding-mqtt.conf/src/main/java/io/aklivity/zilla/config/binding/mqtt/MqttOptionsConfigBuilder.java
@@ -19,8 +19,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public class MqttOptionsConfigBuilder<T> extends ConfigBuilder<T, MqttOptionsConfigBuilder<T>>
@@ -125,7 +125,7 @@ public class MqttOptionsConfigBuilder<T> extends ConfigBuilder<T, MqttOptionsCon
     @Override
     public T build()
     {
-        List<NamedConfig> refs = new ArrayList<>();
+        List<Config.Reference> refs = new ArrayList<>();
         if (topics != null)
         {
             for (MqttTopicConfig topic : topics)

--- a/config/binding-mqtt.conf/src/main/java/io/aklivity/zilla/config/binding/mqtt/MqttTopicConfig.java
+++ b/config/binding-mqtt.conf/src/main/java/io/aklivity/zilla/config/binding/mqtt/MqttTopicConfig.java
@@ -20,20 +20,19 @@ import java.util.List;
 
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class MqttTopicConfig extends Config
 {
     public final String name;
     public final ModelConfig content;
     public final List<MqttUserPropertyConfig> userProperties;
-    private final List<NamedConfig> refs;
+    private final List<Config.Reference> refs;
 
     public MqttTopicConfig(
         String name,
         ModelConfig content,
         List<MqttUserPropertyConfig> userProperties,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         this.name = name;
         this.content = content;
@@ -41,7 +40,7 @@ public class MqttTopicConfig extends Config
         this.refs = refs;
     }
 
-    public List<NamedConfig> refs()
+    public List<Config.Reference> refs()
     {
         return refs;
     }

--- a/config/binding-mqtt.conf/src/main/java/io/aklivity/zilla/config/binding/mqtt/MqttTopicConfigBuilder.java
+++ b/config/binding-mqtt.conf/src/main/java/io/aklivity/zilla/config/binding/mqtt/MqttTopicConfigBuilder.java
@@ -19,9 +19,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class MqttTopicConfigBuilder<T> extends ConfigBuilder<T, MqttTopicConfigBuilder<T>>
 {
@@ -94,7 +94,7 @@ public class MqttTopicConfigBuilder<T> extends ConfigBuilder<T, MqttTopicConfigB
     @Override
     public T build()
     {
-        List<NamedConfig> refs = new ArrayList<>();
+        List<Config.Reference> refs = new ArrayList<>();
         if (content != null)
         {
             refs.addAll(content.refs());

--- a/config/binding-mqtt.conf/src/main/java/io/aklivity/zilla/config/binding/mqtt/MqttUserPropertyConfig.java
+++ b/config/binding-mqtt.conf/src/main/java/io/aklivity/zilla/config/binding/mqtt/MqttUserPropertyConfig.java
@@ -20,25 +20,24 @@ import java.util.List;
 
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class MqttUserPropertyConfig extends Config
 {
     public final String name;
     public final ModelConfig value;
-    private final List<NamedConfig> refs;
+    private final List<Config.Reference> refs;
 
     public MqttUserPropertyConfig(
         String name,
         ModelConfig value,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         this.name = name;
         this.value = value;
         this.refs = refs;
     }
 
-    public List<NamedConfig> refs()
+    public List<Config.Reference> refs()
     {
         return refs;
     }

--- a/config/binding-mqtt.conf/src/main/java/io/aklivity/zilla/config/binding/mqtt/MqttUserPropertyConfigBuilder.java
+++ b/config/binding-mqtt.conf/src/main/java/io/aklivity/zilla/config/binding/mqtt/MqttUserPropertyConfigBuilder.java
@@ -17,9 +17,9 @@ package io.aklivity.zilla.config.binding.mqtt;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class MqttUserPropertyConfigBuilder<T> extends ConfigBuilder<T, MqttUserPropertyConfigBuilder<T>>
 {
@@ -64,7 +64,7 @@ public class MqttUserPropertyConfigBuilder<T> extends ConfigBuilder<T, MqttUserP
     @Override
     public T build()
     {
-        List<NamedConfig> refs = value != null ? value.refs() : List.of();
+        List<Config.Reference> refs = value != null ? value.refs() : List.of();
         return mapper.apply(new MqttUserPropertyConfig(name, value, refs));
     }
 }

--- a/config/binding-sse.conf/src/main/java/io/aklivity/zilla/config/binding/sse/SseOptionsConfig.java
+++ b/config/binding-sse.conf/src/main/java/io/aklivity/zilla/config/binding/sse/SseOptionsConfig.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.config.binding.sse;
 import java.util.List;
 import java.util.function.Function;
 
-import io.aklivity.zilla.config.engine.NamedConfig;
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public final class SseOptionsConfig extends OptionsConfig
@@ -42,7 +42,7 @@ public final class SseOptionsConfig extends OptionsConfig
     SseOptionsConfig(
         int retry,
         List<SseRequestConfig> requests,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super(null, refs);
         this.retry = retry;

--- a/config/binding-sse.conf/src/main/java/io/aklivity/zilla/config/binding/sse/SseOptionsConfigBuilder.java
+++ b/config/binding-sse.conf/src/main/java/io/aklivity/zilla/config/binding/sse/SseOptionsConfigBuilder.java
@@ -19,8 +19,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public class SseOptionsConfigBuilder<T> extends ConfigBuilder<T, SseOptionsConfigBuilder<T>>
@@ -81,7 +81,7 @@ public class SseOptionsConfigBuilder<T> extends ConfigBuilder<T, SseOptionsConfi
     @Override
     public T build()
     {
-        List<NamedConfig> refs = new ArrayList<>();
+        List<Config.Reference> refs = new ArrayList<>();
         if (requests != null)
         {
             for (SseRequestConfig request : requests)

--- a/config/binding-sse.conf/src/main/java/io/aklivity/zilla/config/binding/sse/SsePathConfigBuilder.java
+++ b/config/binding-sse.conf/src/main/java/io/aklivity/zilla/config/binding/sse/SsePathConfigBuilder.java
@@ -17,9 +17,9 @@ package io.aklivity.zilla.config.binding.sse;
 import java.util.List;
 import java.util.function.Function;
 
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class SsePathConfigBuilder<T> extends ConfigBuilder<T, SsePathConfigBuilder<T>>
 {
@@ -64,7 +64,7 @@ public class SsePathConfigBuilder<T> extends ConfigBuilder<T, SsePathConfigBuild
     @Override
     public T build()
     {
-        List<NamedConfig> refs = content != null ? content.refs() : List.of();
+        List<Config.Reference> refs = content != null ? content.refs() : List.of();
         return mapper.apply(new SseRequestConfig(path, content, refs));
     }
 }

--- a/config/binding-sse.conf/src/main/java/io/aklivity/zilla/config/binding/sse/SseRequestConfig.java
+++ b/config/binding-sse.conf/src/main/java/io/aklivity/zilla/config/binding/sse/SseRequestConfig.java
@@ -20,25 +20,24 @@ import java.util.List;
 
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 
 public class SseRequestConfig extends Config
 {
     public final String path;
     public final ModelConfig content;
-    private final List<NamedConfig> refs;
+    private final List<Config.Reference> refs;
 
     SseRequestConfig(
         String path,
         ModelConfig content,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         this.path = path;
         this.content = content;
         this.refs = refs;
     }
 
-    public List<NamedConfig> refs()
+    public List<Config.Reference> refs()
     {
         return refs;
     }

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/BindingConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/BindingConfig.java
@@ -19,9 +19,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 import java.util.function.ToLongFunction;
 
-public abstract class BindingConfig extends Config
+public abstract class BindingConfig extends NamedConfig
 {
-    public transient long id;
     public transient long entryId;
     public transient ToLongFunction<String> resolveId;
 
@@ -37,8 +36,6 @@ public abstract class BindingConfig extends Config
     public transient long routedTypeId;
 
     public final String namespace;
-    public final String name;
-    public final String qname;
     public final String type;
     public final KindConfig kind;
     public final String entry;
@@ -60,8 +57,8 @@ public abstract class BindingConfig extends Config
         List<RouteConfig> routes,
         TelemetryRefConfig telemetryRef)
     {
+        super(name);
         this.namespace = requireNonNull(namespace);
-        this.name = requireNonNull(name);
         this.qname = String.format("%s:%s", namespace, name);
         this.type = requireNonNull(type);
         this.kind = requireNonNull(kind);

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/CatalogConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/CatalogConfig.java
@@ -16,14 +16,11 @@ package io.aklivity.zilla.config.engine;
 
 import static java.util.Objects.requireNonNull;
 
-public abstract class CatalogConfig extends Config
+public abstract class CatalogConfig extends NamedConfig
 {
-    public transient long id;
     public transient long vaultId;
 
     public final String namespace;
-    public final String name;
-    public final String qname;
     public final String type;
     public final String vault;
     public final OptionsConfig options;
@@ -35,8 +32,8 @@ public abstract class CatalogConfig extends Config
         String vault,
         OptionsConfig options)
     {
+        super(name);
         this.namespace = requireNonNull(namespace);
-        this.name = requireNonNull(name);
         this.qname = String.format("%s:%s", namespace, name);
         this.type = requireNonNull(type);
         this.vault = vault;

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/Config.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/Config.java
@@ -23,10 +23,35 @@ public abstract class Config
     {
     }
 
+    /**
+     * A config the engine resolves a name on to an id/qname pair, by the same generic walk regardless of
+     * which concrete kind of reference this is.
+     */
+    public interface Reference
+    {
+        long id();
+
+        String qname();
+
+        void visit(Resolver resolver);
+    }
+
+    /**
+     * Resolves each concrete kind of {@link Reference} to its id/qname pair. Implemented by the engine.
+     */
+    public interface Resolver
+    {
+        void resolve(NamedConfig config);
+
+        void resolve(NamedConfig.Extensible config);
+
+        void resolve(RouteConfig config);
+    }
+
     public abstract static class Extensible extends Config
     {
         private final Map<String, Config> extensions;
-        private final List<NamedConfig> refs;
+        private final List<Reference> refs;
 
         protected Extensible()
         {
@@ -41,7 +66,7 @@ public abstract class Config
 
         protected Extensible(
             Map<String, Config> extensions,
-            List<NamedConfig> refs)
+            List<Reference> refs)
         {
             this.extensions = extensions;
             this.refs = refs != null ? refs : List.of();
@@ -55,11 +80,11 @@ public abstract class Config
         }
 
         /**
-         * Named configs (vaults, guards, ...) contributed by this config or any of its own extensions,
-         * each carrying only a name until the engine resolves it to an id once, generically, regardless of
-         * which concrete kind of named config it is.
+         * Named references (vaults, guards, ...) contributed by this config or any of its own extensions,
+         * each resolved to an id/qname once, generically, regardless of which concrete kind of reference
+         * it is.
          */
-        public final List<NamedConfig> refs()
+        public final List<Reference> refs()
         {
             return refs;
         }

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/ConfigBuilder.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/ConfigBuilder.java
@@ -36,7 +36,7 @@ public abstract class ConfigBuilder<T, B extends ConfigBuilder<T, B>>
     public abstract static class Extensible<T, B extends ConfigBuilder<T, B>> extends ConfigBuilder<T, B>
     {
         private Map<String, Config> extensions;
-        private List<NamedConfig> refs;
+        private List<Config.Reference> refs;
 
         public final <X extends ConfigExtBuilder<B>> X ext(
             Function<BiFunction<String, Config, B>, X> factory)
@@ -57,7 +57,7 @@ public abstract class ConfigBuilder<T, B extends ConfigBuilder<T, B>>
         }
 
         public final B ref(
-            NamedConfig ref)
+            Config.Reference ref)
         {
             if (refs == null)
             {
@@ -72,7 +72,7 @@ public abstract class ConfigBuilder<T, B extends ConfigBuilder<T, B>>
             return extensions;
         }
 
-        protected final List<NamedConfig> refs()
+        protected final List<Config.Reference> refs()
         {
             return refs != null ? refs : List.of();
         }

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/ConfigExtAdapter.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/ConfigExtAdapter.java
@@ -196,7 +196,7 @@ public final class ConfigExtAdapter<T extends Config.Extensible>
         B adapted = builder.ext(name, extension);
         if (extension instanceof Config.Extensible extensible)
         {
-            for (NamedConfig ref : extensible.refs())
+            for (Config.Reference ref : extensible.refs())
             {
                 adapted = adapted.ref(ref);
             }

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/EmbeddedConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/EmbeddedConfig.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.config.engine;
 import java.util.Map;
 import java.util.function.Function;
 
-public final class EmbeddedConfig extends NamedConfig
+public final class EmbeddedConfig extends NamedConfig.Extensible
 {
     EmbeddedConfig(
         String name,

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/ExporterConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/ExporterConfig.java
@@ -16,16 +16,13 @@ package io.aklivity.zilla.config.engine;
 
 import static java.util.Objects.requireNonNull;
 
-public abstract class ExporterConfig extends Config
+public abstract class ExporterConfig extends NamedConfig
 {
     public final String namespace;
-    public final String name;
-    public final String qname;
     public final String type;
     public final String vault;
     public final OptionsConfig options;
 
-    public transient long id;
     public transient long vaultId;
 
     protected ExporterConfig(
@@ -35,8 +32,8 @@ public abstract class ExporterConfig extends Config
         String vault,
         OptionsConfig options)
     {
+        super(name);
         this.namespace = requireNonNull(namespace);
-        this.name = requireNonNull(name);
         this.qname = String.format("%s:%s", namespace, name);
         this.type = requireNonNull(type);
         this.vault = vault;

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/GuardConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/GuardConfig.java
@@ -18,16 +18,13 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.function.ToLongFunction;
 
-public abstract class GuardConfig extends Config
+public abstract class GuardConfig extends NamedConfig
 {
-    public transient long id;
     public transient long storeId;
     public transient String qstore;
     public transient ToLongFunction<String> resolveId;
 
     public final String namespace;
-    public final String name;
-    public final String qname;
     public final String type;
     public final String kind;
     public final String store;
@@ -41,8 +38,8 @@ public abstract class GuardConfig extends Config
         String store,
         OptionsConfig options)
     {
+        super(name);
         this.namespace = requireNonNull(namespace);
-        this.name = requireNonNull(name);
         this.qname = String.format("%s:%s", namespace, name);
         this.type = requireNonNull(type);
         this.kind = kind;

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/GuardedConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/GuardedConfig.java
@@ -27,7 +27,6 @@ public class GuardedConfig extends NamedConfig
 {
     public transient LongFunction<String> identity;
     public transient LongObjectBiFunction<String, String> attributes;
-    public transient String qname;
 
     public final List<String> roles;
 

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/ModelConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/ModelConfig.java
@@ -46,7 +46,7 @@ public abstract class ModelConfig extends Config.Extensible
         List<CatalogedConfig> cataloged,
         ValidateConfig validate,
         Map<String, Config> extensions,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super(extensions, withCataloged(cataloged, refs));
         this.model = model;
@@ -54,15 +54,15 @@ public abstract class ModelConfig extends Config.Extensible
         this.validate = validate != null ? validate : ValidateConfig.STRICT;
     }
 
-    // cataloged and each of its schemas' overlay are themselves NamedConfig, so folding them into refs
+    // cataloged and each of its schemas' overlay are themselves named references, so folding them into refs
     // lets the engine resolve every name this model carries -- cataloged, overlay, and whatever an
     // installed extension contributed -- with one generic walk, rather than a schema-specific walk plus
     // a separate generic one
-    private static List<NamedConfig> withCataloged(
+    private static List<Config.Reference> withCataloged(
         List<CatalogedConfig> cataloged,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
-        List<NamedConfig> all = new ArrayList<>();
+        List<Config.Reference> all = new ArrayList<>();
         if (cataloged != null)
         {
             all.addAll(cataloged);

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/NamedConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/NamedConfig.java
@@ -20,14 +20,15 @@ import java.util.Map;
 
 /**
  * A config entry that names something resolved elsewhere in the same namespace (a vault, a guard, ...),
- * carrying only the name at config-load time. The engine resolves {@code name} to {@code id} once, by
- * the same generic walk regardless of which concrete kind of named config this is.
+ * carrying only the name at config-load time. The engine resolves {@code name} to {@code id}/{@code qname}
+ * once, by the same generic walk regardless of which concrete kind of named config this is.
  *
- * @see Config.Extensible#refs()
+ * @see Config#refs()
  */
-public abstract class NamedConfig extends Config.Extensible
+public abstract class NamedConfig extends Config.Extensible implements Config.Reference
 {
     public transient long id;
+    public transient String qname;
 
     public final String name;
 
@@ -43,5 +44,71 @@ public abstract class NamedConfig extends Config.Extensible
     {
         super(extensions);
         this.name = requireNonNull(name);
+    }
+
+    @Override
+    public long id()
+    {
+        return id;
+    }
+
+    @Override
+    public String qname()
+    {
+        return qname;
+    }
+
+    @Override
+    public void visit(
+        Config.Resolver resolver)
+    {
+        resolver.resolve(this);
+    }
+
+    /**
+     * A named config that also carries its own named extensions/refs (a vault, a store, an embedding, ...).
+     * Independent of {@link NamedConfig} (Java single inheritance won't let one extend the other while both
+     * also extend their respective {@link Config}/{@link Config.Extensible} base), but both implement
+     * {@link Config.Reference} so either kind can appear in the same {@link Config#refs()} list.
+     */
+    public abstract static class Extensible extends Config.Extensible implements Config.Reference
+    {
+        public transient long id;
+        public transient String qname;
+
+        public final String name;
+
+        protected Extensible(
+            String name)
+        {
+            this(name, null);
+        }
+
+        protected Extensible(
+            String name,
+            Map<String, Config> extensions)
+        {
+            super(extensions);
+            this.name = requireNonNull(name);
+        }
+
+        @Override
+        public long id()
+        {
+            return id;
+        }
+
+        @Override
+        public String qname()
+        {
+            return qname;
+        }
+
+        @Override
+        public void visit(
+            Config.Resolver resolver)
+        {
+            resolver.resolve(this);
+        }
     }
 }

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/OptionsConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/OptionsConfig.java
@@ -24,7 +24,7 @@ public class OptionsConfig extends Config.Extensible
 
     public OptionsConfig(
         Map<String, Config> extensions,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         this(Collections.emptyList(), extensions, refs);
     }
@@ -32,7 +32,7 @@ public class OptionsConfig extends Config.Extensible
     public OptionsConfig(
         List<String> resources,
         Map<String, Config> extensions,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super(extensions, refs);
         this.resources = resources;

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/RouteConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/RouteConfig.java
@@ -23,9 +23,10 @@ import java.util.function.UnaryOperator;
 
 import io.aklivity.zilla.runtime.common.lang.util.function.LongObjectPredicate;
 
-public class RouteConfig extends Config
+public class RouteConfig extends Config implements Config.Reference
 {
     public transient long id;
+    public transient String qname;
     public transient LongObjectPredicate<UnaryOperator<String>> authorized;
     public transient ToLongFunction<String> resolveId;
 
@@ -52,5 +53,24 @@ public class RouteConfig extends Config
         this.when = requireNonNull(when);
         this.with = with;
         this.guarded = requireNonNull(guarded);
+    }
+
+    @Override
+    public long id()
+    {
+        return id;
+    }
+
+    @Override
+    public String qname()
+    {
+        return qname;
+    }
+
+    @Override
+    public void visit(
+        Config.Resolver resolver)
+    {
+        resolver.resolve(this);
     }
 }

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/StoreConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/StoreConfig.java
@@ -16,13 +16,9 @@ package io.aklivity.zilla.config.engine;
 
 import static java.util.Objects.requireNonNull;
 
-public abstract class StoreConfig extends Config
+public abstract class StoreConfig extends NamedConfig
 {
-    public transient long id;
-
     public final String namespace;
-    public final String name;
-    public final String qname;
     public final String type;
     public final OptionsConfig options;
 
@@ -32,8 +28,8 @@ public abstract class StoreConfig extends Config
         String type,
         OptionsConfig options)
     {
+        super(name);
         this.namespace = requireNonNull(namespace);
-        this.name = requireNonNull(name);
         this.qname = String.format("%s:%s", namespace, name);
         this.type = requireNonNull(type);
         this.options = options;

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/StoredConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/StoredConfig.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.config.engine;
 import java.util.Map;
 import java.util.function.Function;
 
-public final class StoredConfig extends NamedConfig
+public final class StoredConfig extends NamedConfig.Extensible
 {
     StoredConfig(
         String name,

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/VaultConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/VaultConfig.java
@@ -16,14 +16,11 @@ package io.aklivity.zilla.config.engine;
 
 import static java.util.Objects.requireNonNull;
 
-public abstract class VaultConfig extends Config
+public abstract class VaultConfig extends NamedConfig
 {
-    public transient long id;
     public transient boolean local;
 
     public final String namespace;
-    public final String name;
-    public final String qname;
     public final String type;
     public final OptionsConfig options;
 
@@ -33,7 +30,7 @@ public abstract class VaultConfig extends Config
         String type,
         OptionsConfig options)
     {
-        this.name = requireNonNull(name);
+        super(name);
         this.namespace = requireNonNull(namespace);
         this.qname = String.format("%s:%s", namespace, name);
         this.type = requireNonNull(type);

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/VaultedConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/VaultedConfig.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.config.engine;
 import java.util.Map;
 import java.util.function.Function;
 
-public final class VaultedConfig extends NamedConfig
+public final class VaultedConfig extends NamedConfig.Extensible
 {
     VaultedConfig(
         String name,

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/binding/config/TestBindingOptionsConfig.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/binding/config/TestBindingOptionsConfig.java
@@ -19,8 +19,8 @@ import java.util.List;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.CatalogedConfig;
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public final class TestBindingOptionsConfig extends OptionsConfig
@@ -66,7 +66,7 @@ public final class TestBindingOptionsConfig extends OptionsConfig
         String embedding,
         List<EnvelopeValue> envelope,
         List<EnvelopeAssertion> envelopeAssertions,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super(null, refs);
         this.value = value;

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/binding/config/TestBindingOptionsConfigBuilder.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/binding/config/TestBindingOptionsConfigBuilder.java
@@ -20,9 +20,9 @@ import java.util.Map;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.CatalogedConfig;
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigBuilder;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.OptionsConfig;
 import io.aklivity.zilla.config.engine.test.internal.binding.config.TestBindingOptionsConfig.VaultAssertion;
 
@@ -256,7 +256,7 @@ public final class TestBindingOptionsConfigBuilder<T> extends ConfigBuilder<T, T
     @Override
     public T build()
     {
-        List<NamedConfig> refs = value != null ? value.refs() : List.of();
+        List<Config.Reference> refs = value != null ? value.refs() : List.of();
         return mapper.apply(new TestBindingOptionsConfig(value, mode, schema, authorization, catalogs, events,
                 metrics, catalogAssertions, vaultAssertion, store, storeAssertions, embedding, envelope, envelopeAssertions,
                 refs));

--- a/config/model-avro.conf/src/main/java/io/aklivity/zilla/config/model/avro/AvroModelConfig.java
+++ b/config/model-avro.conf/src/main/java/io/aklivity/zilla/config/model/avro/AvroModelConfig.java
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import io.aklivity.zilla.config.engine.CatalogedConfig;
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.ValidateConfig;
 
 public final class AvroModelConfig extends ModelConfig
@@ -35,7 +34,7 @@ public final class AvroModelConfig extends ModelConfig
         String view,
         ValidateConfig validate,
         Map<String, Config> extensions,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super("avro", cataloged, validate, extensions, refs);
         this.subject = subject;

--- a/config/model-core.conf/src/main/java/io/aklivity/zilla/config/model/core/BytesModelConfig.java
+++ b/config/model-core.conf/src/main/java/io/aklivity/zilla/config/model/core/BytesModelConfig.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.ValidateConfig;
 
 public final class BytesModelConfig extends ModelConfig
@@ -28,7 +27,7 @@ public final class BytesModelConfig extends ModelConfig
     BytesModelConfig(
         ValidateConfig validate,
         Map<String, Config> extensions,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super("bytes", null, validate, extensions, refs);
     }

--- a/config/model-core.conf/src/main/java/io/aklivity/zilla/config/model/core/StringModelConfig.java
+++ b/config/model-core.conf/src/main/java/io/aklivity/zilla/config/model/core/StringModelConfig.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.ValidateConfig;
 
 public final class StringModelConfig extends ModelConfig
@@ -37,7 +36,7 @@ public final class StringModelConfig extends ModelConfig
         int minLength,
         ValidateConfig validate,
         Map<String, Config> extensions,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super("string", null, validate, extensions, refs);
         this.encoding = encoding;

--- a/config/model-core.conf/src/test/java/io/aklivity/zilla/config/model/core/BytesModelConfigTest.java
+++ b/config/model-core.conf/src/test/java/io/aklivity/zilla/config/model/core/BytesModelConfigTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.junit.Test;
 
-import io.aklivity.zilla.config.engine.NamedConfig;
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.VaultedConfig;
 
 public class BytesModelConfigTest
@@ -36,7 +36,7 @@ public class BytesModelConfigTest
             .ref(vaulted)
             .build();
 
-        List<NamedConfig> refs = config.refs();
+        List<Config.Reference> refs = config.refs();
         assertThat(refs, hasItem(vaulted));
     }
 

--- a/config/model-core.conf/src/test/java/io/aklivity/zilla/config/model/core/StringModelConfigTest.java
+++ b/config/model-core.conf/src/test/java/io/aklivity/zilla/config/model/core/StringModelConfigTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.junit.Test;
 
-import io.aklivity.zilla.config.engine.NamedConfig;
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.VaultedConfig;
 
 public class StringModelConfigTest
@@ -36,7 +36,7 @@ public class StringModelConfigTest
             .ref(vaulted)
             .build();
 
-        List<NamedConfig> refs = config.refs();
+        List<Config.Reference> refs = config.refs();
         assertThat(refs, hasItem(vaulted));
     }
 

--- a/config/model-json.conf/src/main/java/io/aklivity/zilla/config/model/json/JsonModelConfig.java
+++ b/config/model-json.conf/src/main/java/io/aklivity/zilla/config/model/json/JsonModelConfig.java
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import io.aklivity.zilla.config.engine.CatalogedConfig;
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.ValidateConfig;
 
 public final class JsonModelConfig extends ModelConfig
@@ -33,7 +32,7 @@ public final class JsonModelConfig extends ModelConfig
         String subject,
         ValidateConfig validate,
         Map<String, Config> extensions,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super("json", cataloged, validate, extensions, refs);
         this.subject = subject;

--- a/config/model-protobuf.conf/src/main/java/io/aklivity/zilla/config/model/protobuf/ProtobufModelConfig.java
+++ b/config/model-protobuf.conf/src/main/java/io/aklivity/zilla/config/model/protobuf/ProtobufModelConfig.java
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import io.aklivity.zilla.config.engine.CatalogedConfig;
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.ValidateConfig;
 
 public final class ProtobufModelConfig extends ModelConfig
@@ -35,7 +34,7 @@ public final class ProtobufModelConfig extends ModelConfig
         String view,
         ValidateConfig validate,
         Map<String, Config> extensions,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super("protobuf", cataloged, validate, extensions, refs);
         this.subject = subject;

--- a/incubator/model-vector.conf/src/main/java/io/aklivity/zilla/config/model/vector/VectorModelConfig.java
+++ b/incubator/model-vector.conf/src/main/java/io/aklivity/zilla/config/model/vector/VectorModelConfig.java
@@ -22,7 +22,6 @@ import java.util.function.Function;
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.EmbeddedConfig;
 import io.aklivity.zilla.config.engine.ModelConfig;
-import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.StoredConfig;
 
 public final class VectorModelConfig extends ModelConfig
@@ -38,7 +37,7 @@ public final class VectorModelConfig extends ModelConfig
         double threshold,
         StoredConfig store,
         Map<String, Config> extensions,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
         super("vector", null, null, extensions, withRefs(embedding, store, refs));
         this.embedding = embedding;
@@ -58,12 +57,12 @@ public final class VectorModelConfig extends ModelConfig
         return new VectorModelConfigBuilder<>(VectorModelConfig.class::cast);
     }
 
-    private static List<NamedConfig> withRefs(
+    private static List<Config.Reference> withRefs(
         EmbeddedConfig embedding,
         StoredConfig store,
-        List<NamedConfig> refs)
+        List<Config.Reference> refs)
     {
-        List<NamedConfig> all = new ArrayList<>();
+        List<Config.Reference> all = new ArrayList<>();
         if (embedding != null)
         {
             all.add(embedding);

--- a/runtime/binding-mcp-kafka-connect/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/connect/internal/config/McpKafkaConnectBindingConfig.java
+++ b/runtime/binding-mcp-kafka-connect/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/connect/internal/config/McpKafkaConnectBindingConfig.java
@@ -69,6 +69,6 @@ public final class McpKafkaConnectBindingConfig
             .filter(route -> route.exit != null)
             .findFirst()
             .orElse(null);
-        this.exit = exitRoute != null ? context.supplyQName(exitRoute.id) : null;
+        this.exit = exitRoute != null ? exitRoute.qname() : null;
     }
 }

--- a/runtime/binding-mcp-kafka-connect/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/connect/internal/config/composite/McpKafkaConnectCompositeGenerator.java
+++ b/runtime/binding-mcp-kafka-connect/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/connect/internal/config/composite/McpKafkaConnectCompositeGenerator.java
@@ -136,7 +136,7 @@ public final class McpKafkaConnectCompositeGenerator
                 mcpOpenapi.route()
                     .when(McpOpenapiConditionConfig.builder().tool(tool).build())
                     .with(McpOpenapiWithConfig.builder().spec(SUBJECT_NAME).operation(tool).build())
-                    .inject(route -> injectGuarded(route, binding, guarded))
+                    .inject(route -> injectGuarded(route, guarded))
                     .build();
             }
         }
@@ -162,12 +162,11 @@ public final class McpKafkaConnectCompositeGenerator
 
     private <C> McpOpenapiRouteConfigBuilder<C> injectGuarded(
         McpOpenapiRouteConfigBuilder<C> route,
-        McpKafkaConnectBindingConfig binding,
         List<GuardedConfig> guarded)
     {
         for (GuardedConfig guard : guarded)
         {
-            String qname = binding.supplyQName.apply(binding.resolveId.applyAsLong(guard.name));
+            String qname = guard.qname();
             route.guarded()
                 .name(qname)
                 .inject(g -> injectRoles(g, guard.roles))

--- a/runtime/binding-mcp-kafka-connect/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/connect/internal/config/composite/McpKafkaConnectCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-kafka-connect/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/connect/internal/config/composite/McpKafkaConnectCompositeGeneratorTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -245,8 +244,6 @@ public class McpKafkaConnectCompositeGeneratorTest
     @Test
     public void shouldGuardDeclaredRoute()
     {
-        when(context.supplyQName(eq(3L))).thenReturn("test:jwt0");
-
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
@@ -266,6 +263,7 @@ public class McpKafkaConnectCompositeGeneratorTest
                 .build()
             .build();
         binding.resolveId = name -> "jwt0".equals(name) ? 3L : 2L;
+        binding.routes.get(0).guarded.get(0).qname = "test:jwt0";
 
         McpKafkaConnectBindingConfig attached = new McpKafkaConnectBindingConfig(context, binding);
 
@@ -286,8 +284,6 @@ public class McpKafkaConnectCompositeGeneratorTest
     @Test
     public void shouldGenerateCompositeForProxyKind()
     {
-        when(context.supplyQName(eq(5L))).thenReturn("test:http0");
-
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
@@ -295,11 +291,12 @@ public class McpKafkaConnectCompositeGeneratorTest
             .kind(PROXY)
             .exit("http0")
             .build();
-        binding.routes.stream()
+        RouteConfig inputExitRoute = binding.routes.stream()
             .filter(route -> "http0".equals(route.exit))
             .findFirst()
-            .orElseThrow()
-            .id = 5L;
+            .orElseThrow();
+        inputExitRoute.id = 5L;
+        inputExitRoute.qname = "test:http0";
 
         McpKafkaConnectBindingConfig attached = new McpKafkaConnectBindingConfig(context, binding);
 

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiBindingConfig.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiBindingConfig.java
@@ -64,7 +64,7 @@ public final class McpOpenapiBindingConfig
         // a declared route always has with, so with == null is what uniquely identifies the synthetic one
         this.routes = binding.routes.stream()
             .filter(route -> route.with != null)
-            .map(route -> new McpOpenapiRouteConfig(context, route))
+            .map(McpOpenapiRouteConfig::new)
             .collect(toList());
 
         final RouteConfig exitRoute = binding.routes.stream()

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiBindingConfig.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiBindingConfig.java
@@ -71,7 +71,7 @@ public final class McpOpenapiBindingConfig
             .filter(route -> route.with == null && route.exit != null)
             .findFirst()
             .orElse(null);
-        this.exit = exitRoute != null ? context.supplyQName(exitRoute.id) : null;
+        this.exit = exitRoute != null ? exitRoute.qname() : null;
 
         this.resolveId = binding.resolveId;
         this.supplyBindingId = context::supplyBindingId;

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiRouteConfig.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiRouteConfig.java
@@ -22,7 +22,6 @@ import io.aklivity.zilla.config.binding.mcp.openapi.McpOpenapiConditionConfig;
 import io.aklivity.zilla.config.binding.mcp.openapi.McpOpenapiWithConfig;
 import io.aklivity.zilla.config.engine.GuardedConfig;
 import io.aklivity.zilla.config.engine.RouteConfig;
-import io.aklivity.zilla.runtime.engine.EngineContext;
 
 public final class McpOpenapiRouteConfig
 {
@@ -33,7 +32,6 @@ public final class McpOpenapiRouteConfig
     public final String exit;
 
     public McpOpenapiRouteConfig(
-        EngineContext context,
         RouteConfig route)
     {
         this.id = route.id;
@@ -42,7 +40,7 @@ public final class McpOpenapiRouteConfig
             .collect(toList());
         this.with = (McpOpenapiWithConfig) route.with;
         this.guarded = route.guarded;
-        this.exit = route.exit != null ? context.supplyQName(route.id) : null;
+        this.exit = route.exit != null ? route.qname() : null;
     }
 
     public boolean isBulk()

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -203,7 +203,7 @@ public final class McpOpenapiCompositeGenerator
                     continue;
                 }
 
-                final List<GuardedRef> guarded = combineGuarded(binding, route, resolution.guarded);
+                final List<GuardedRef> guarded = combineGuarded(route, resolution.guarded);
 
                 routed.add(new RoutedOperation(toolConfig(binding, routeTool), resourceConfig(binding, resource),
                     operation, guarded, exit, serverByLabel.get(with.spec), with.params, with.body));
@@ -736,7 +736,6 @@ public final class McpOpenapiCompositeGenerator
     }
 
     private static List<GuardedRef> combineGuarded(
-        McpOpenapiBindingConfig binding,
         McpOpenapiRouteConfig route,
         List<GuardedRef> derived)
     {
@@ -751,7 +750,7 @@ public final class McpOpenapiCompositeGenerator
             }
             for (GuardedConfig guarded : route.guarded)
             {
-                final String qname = binding.supplyQName.apply(binding.resolveId.applyAsLong(guarded.name));
+                final String qname = guarded.qname();
                 rolesByQName.computeIfAbsent(qname, q -> new ArrayList<>()).addAll(guarded.roles);
             }
 

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
@@ -3425,8 +3425,6 @@ public class McpOpenapiCompositeGeneratorTest
     @Test
     public void shouldGenerateProxyKindMcpHttpFromRouteExit()
     {
-        lenient().when(context.supplyQName(eq(9L))).thenReturn("test:http0");
-
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp-openapi0")
@@ -3455,11 +3453,12 @@ public class McpOpenapiCompositeGeneratorTest
                 .build()
             .build();
         binding.resolveId = resolveId;
-        binding.routes.stream()
+        RouteConfig exitRoute = binding.routes.stream()
             .filter(route -> "http0".equals(route.exit))
             .findFirst()
-            .orElseThrow()
-            .id = 9L;
+            .orElseThrow();
+        exitRoute.id = 9L;
+        exitRoute.qname = "test:http0";
 
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
@@ -3477,9 +3476,6 @@ public class McpOpenapiCompositeGeneratorTest
     @Test
     public void shouldGenerateProxyKindMcpHttpWithDifferentExitPerRoute()
     {
-        lenient().when(context.supplyQName(eq(10L))).thenReturn("test:http0");
-        lenient().when(context.supplyQName(eq(11L))).thenReturn("test:http1");
-
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp-openapi0")
@@ -3518,16 +3514,18 @@ public class McpOpenapiCompositeGeneratorTest
                 .build()
             .build();
         binding.resolveId = resolveId;
-        binding.routes.stream()
+        RouteConfig http0Route = binding.routes.stream()
             .filter(route -> "http0".equals(route.exit))
             .findFirst()
-            .orElseThrow()
-            .id = 10L;
-        binding.routes.stream()
+            .orElseThrow();
+        http0Route.id = 10L;
+        http0Route.qname = "test:http0";
+        RouteConfig http1Route = binding.routes.stream()
             .filter(route -> "http1".equals(route.exit))
             .findFirst()
-            .orElseThrow()
-            .id = 11L;
+            .orElseThrow();
+        http1Route.id = 11L;
+        http1Route.qname = "test:http1";
 
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
@@ -3560,8 +3558,6 @@ public class McpOpenapiCompositeGeneratorTest
     @Test
     public void shouldGenerateProxyKindMcpHttpRouteExitFallingBackToBindingExit()
     {
-        lenient().when(context.supplyQName(eq(12L))).thenReturn("test:http0");
-
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp-openapi0")
@@ -3590,11 +3586,12 @@ public class McpOpenapiCompositeGeneratorTest
                 .build()
             .build();
         binding.resolveId = resolveId;
-        binding.routes.stream()
+        RouteConfig exitRoute = binding.routes.stream()
             .filter(route -> "http0".equals(route.exit))
             .findFirst()
-            .orElseThrow()
-            .id = 12L;
+            .orElseThrow();
+        exitRoute.id = 12L;
+        exitRoute.qname = "test:http0";
 
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
@@ -548,8 +548,6 @@ public class McpOpenapiCompositeGeneratorTest
     @Test
     public void shouldGenerateProxyKindMcpHttpFromProxyKindExit()
     {
-        lenient().when(context.supplyQName(eq(9L))).thenReturn("test:schema_registry0");
-
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp-openapi0")
@@ -578,11 +576,12 @@ public class McpOpenapiCompositeGeneratorTest
                 .build()
             .build();
         binding.resolveId = resolveId;
-        binding.routes.stream()
+        RouteConfig exitRoute = binding.routes.stream()
             .filter(route -> "schema_registry0".equals(route.exit))
             .findFirst()
-            .orElseThrow()
-            .id = 9L;
+            .orElseThrow();
+        exitRoute.id = 9L;
+        exitRoute.qname = "test:schema_registry0";
 
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
@@ -2179,6 +2178,7 @@ public class McpOpenapiCompositeGeneratorTest
                 .build()
             .build();
         binding.resolveId = resolveId;
+        binding.routes.get(0).guarded.get(0).qname = "test1";
 
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
@@ -2231,6 +2231,7 @@ public class McpOpenapiCompositeGeneratorTest
                 .build()
             .build();
         binding.resolveId = resolveId;
+        binding.routes.get(0).guarded.get(0).qname = "test1";
 
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
@@ -2287,6 +2288,7 @@ public class McpOpenapiCompositeGeneratorTest
                 .build()
             .build();
         binding.resolveId = resolveId;
+        binding.routes.get(0).guarded.get(0).qname = "test0";
 
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 

--- a/runtime/binding-mcp-schema-registry/src/main/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/McpSchemaRegistryBindingConfig.java
+++ b/runtime/binding-mcp-schema-registry/src/main/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/McpSchemaRegistryBindingConfig.java
@@ -69,6 +69,6 @@ public final class McpSchemaRegistryBindingConfig
             .filter(route -> route.exit != null)
             .findFirst()
             .orElse(null);
-        this.exit = exitRoute != null ? context.supplyQName(exitRoute.id) : null;
+        this.exit = exitRoute != null ? exitRoute.qname() : null;
     }
 }

--- a/runtime/binding-mcp-schema-registry/src/main/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/composite/McpSchemaRegistryCompositeGenerator.java
+++ b/runtime/binding-mcp-schema-registry/src/main/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/composite/McpSchemaRegistryCompositeGenerator.java
@@ -132,7 +132,7 @@ public final class McpSchemaRegistryCompositeGenerator
                 mcpOpenapi.route()
                     .when(McpOpenapiConditionConfig.builder().tool(tool).build())
                     .with(McpOpenapiWithConfig.builder().spec(SUBJECT_NAME).operation(tool).build())
-                    .inject(route -> injectGuarded(route, binding, guarded))
+                    .inject(route -> injectGuarded(route, guarded))
                     .build();
             }
         }
@@ -158,12 +158,11 @@ public final class McpSchemaRegistryCompositeGenerator
 
     private <C> McpOpenapiRouteConfigBuilder<C> injectGuarded(
         McpOpenapiRouteConfigBuilder<C> route,
-        McpSchemaRegistryBindingConfig binding,
         List<GuardedConfig> guarded)
     {
         for (GuardedConfig guard : guarded)
         {
-            String qname = binding.supplyQName.apply(binding.resolveId.applyAsLong(guard.name));
+            String qname = guard.qname();
             route.guarded()
                 .name(qname)
                 .inject(g -> injectRoles(g, guard.roles))

--- a/runtime/binding-mcp-schema-registry/src/test/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/composite/McpSchemaRegistryCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-schema-registry/src/test/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/composite/McpSchemaRegistryCompositeGeneratorTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -240,8 +239,6 @@ public class McpSchemaRegistryCompositeGeneratorTest
     @Test
     public void shouldGuardDeclaredRoute()
     {
-        when(context.supplyQName(eq(3L))).thenReturn("test:jwt0");
-
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
@@ -261,6 +258,7 @@ public class McpSchemaRegistryCompositeGeneratorTest
                 .build()
             .build();
         binding.resolveId = name -> "jwt0".equals(name) ? 3L : 2L;
+        binding.routes.get(0).guarded.get(0).qname = "test:jwt0";
 
         McpSchemaRegistryBindingConfig attached = new McpSchemaRegistryBindingConfig(context, binding);
 
@@ -281,8 +279,6 @@ public class McpSchemaRegistryCompositeGeneratorTest
     @Test
     public void shouldGenerateCompositeForProxyKind()
     {
-        when(context.supplyQName(eq(5L))).thenReturn("test:http0");
-
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
@@ -290,11 +286,12 @@ public class McpSchemaRegistryCompositeGeneratorTest
             .kind(PROXY)
             .exit("http0")
             .build();
-        binding.routes.stream()
+        RouteConfig inputExitRoute = binding.routes.stream()
             .filter(route -> "http0".equals(route.exit))
             .findFirst()
-            .orElseThrow()
-            .id = 5L;
+            .orElseThrow();
+        inputExitRoute.id = 5L;
+        inputExitRoute.qname = "test:http0";
 
         McpSchemaRegistryBindingConfig attached = new McpSchemaRegistryBindingConfig(context, binding);
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
@@ -48,6 +48,7 @@ import jakarta.json.spi.JsonProvider;
 import io.aklivity.zilla.config.engine.BindingConfig;
 import io.aklivity.zilla.config.engine.CatalogConfig;
 import io.aklivity.zilla.config.engine.CatalogedConfig;
+import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ConfigException;
 import io.aklivity.zilla.config.engine.EngineConfig;
 import io.aklivity.zilla.config.engine.EngineConfigReader;
@@ -384,9 +385,9 @@ public class EngineManager
 
             if (vault.options != null)
             {
-                for (NamedConfig ref : vault.options.refs())
+                for (Config.Reference ref : vault.options.refs())
                 {
-                    ref.id = resolver.resolve(ref.name);
+                    ref.visit(resolver);
                 }
             }
         }
@@ -445,15 +446,15 @@ public class EngineManager
 
             if (binding.options != null)
             {
-                for (NamedConfig ref : binding.options.refs())
+                for (Config.Reference ref : binding.options.refs())
                 {
-                    ref.id = resolver.resolve(ref.name);
+                    ref.visit(resolver);
                 }
             }
 
             for (RouteConfig route : binding.routes)
             {
-                route.id = resolver.resolve(route.exit);
+                route.visit(resolver);
                 route.authorized = (session, resolve) -> true;
                 route.resolveId = binding.resolveId;
 
@@ -461,7 +462,7 @@ public class EngineManager
                 {
                     for (GuardedConfig guarded : route.guarded)
                     {
-                        guarded.id = resolver.resolve(guarded.name);
+                        guarded.visit(resolver);
 
                         LongObjectPredicate<UnaryOperator<String>> authorizer = guards.stream()
                             .filter(g -> g.id == guarded.id)
@@ -487,8 +488,6 @@ public class EngineManager
                             .orElse((session, name) -> null);
 
                         guarded.attributes = attributor;
-
-                        guarded.qname = resolver.format(guarded.id);
 
                         route.authorized = route.authorized.and(authorizer);
                     }
@@ -599,7 +598,7 @@ public class EngineManager
         }
     }
 
-    private final class NameResolver
+    private final class NameResolver implements Config.Resolver
     {
         private final int namespaceId;
         private final ThreadLocal<Matcher> matchName;
@@ -635,6 +634,30 @@ public class EngineManager
             return String.format("%s:%s",
                     supplyName.apply(NamespacedId.namespaceId(namespacedId)),
                     supplyName.apply(NamespacedId.localId(namespacedId)));
+        }
+
+        @Override
+        public void resolve(
+            NamedConfig config)
+        {
+            config.id = resolve(config.name);
+            config.qname = format(config.id);
+        }
+
+        @Override
+        public void resolve(
+            NamedConfig.Extensible config)
+        {
+            config.id = resolve(config.name);
+            config.qname = format(config.id);
+        }
+
+        @Override
+        public void resolve(
+            RouteConfig config)
+        {
+            config.id = resolve(config.exit);
+            config.qname = format(config.id);
         }
     }
 


### PR DESCRIPTION
## Description

`RouteConfig` now gets an engine-populated `qname`, resolved once during `EngineManager.process()` alongside `id`, the same way `GuardedConfig.qname` already worked. This is generalized via a small `Config.Reference`/`Config.Resolver` contract so any reference (route, guard, catalog, vault, store, embedding) is resolved uniformly, without each composite binding re-deriving a qname itself via `context.supplyQName(id)` after the fact.

- `Config.Reference` (`id()`, `qname()`, `visit(Resolver)`) is implemented independently by `NamedConfig` (the existing plain case: `GuardedConfig`, `CatalogedConfig`, `OverlayConfig`), the new `NamedConfig.Extensible` (the extensions-carrying case: `VaultedConfig`, `StoredConfig`, `EmbeddedConfig`), and `RouteConfig` (whose `exit`, unlike `NamedConfig.name`, is legitimately nullable).
- `BindingConfig`, `GuardConfig`, `VaultConfig`, `CatalogConfig`, `StoreConfig`, `ExporterConfig` now extend `NamedConfig`, removing their own hand-duplicated `id`/`name`/`qname` fields. Their `qname` stays eagerly computed in the constructor (not routed through `.visit()`), so it remains available immediately after construction rather than only after config processing.
- `EngineManager`'s `NameResolver` implements `Config.Resolver`, so the generic ref-resolution loops and the route/guarded loops call `.visit(resolver)` instead of hand-assigning `id`/`qname`.
- The three composite MCP bindings (`mcp-openapi`, `mcp-kafka-connect`, `mcp-schema-registry`) and their composite generators now read `route.qname()`/`guard.qname()` off the already-resolved reference instead of calling `context.supplyQName(id)` again.

No behavior change for anything reading these fields today — this only relocates *where* `qname` is computed and removes duplication across the six top-level config classes.

Rebased onto latest `develop` (picking up #2565's per-route exit resolution for `mcp-openapi`); `McpOpenapiRouteConfig`'s own `context.supplyQName(route.id)` call (added by #2565, independently of this change) is updated to `route.qname()` for the same reason.

## Test plan

- `./mvnw clean package` across all touched modules: 0 checkstyle violations, all unit tests pass
- `./mvnw clean verify` (full k3po IT suite, all 42 reactor modules): BUILD SUCCESS
- `./mvnw clean verify -pl runtime/binding-mcp-openapi,runtime/binding-mcp-kafka-connect,runtime/binding-mcp-schema-registry -am`: unit tests and k3po ITs pass for all three composite MCP bindings, confirming the `route.qname()`/`guard.qname()` substitution produces identical runtime behavior to `context.supplyQName(id)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WF7FVoCe2rovFmkWB8sbtt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WF7FVoCe2rovFmkWB8sbtt)_